### PR TITLE
17 connect commercial landings with processed products

### DIFF
--- a/1_data_pulls.R
+++ b/1_data_pulls.R
@@ -51,6 +51,8 @@ drive_auth()
 #                overwrite = T)
 # drive_download('foss_com_landings_15-23.csv',
 #                overwrite = T)
+# drive_download('Assessment_Summary_Data.csv',
+#                overwrite = T)
 
 ##################################
 ### LOAD DOWNLOADED DATA FILES ###
@@ -115,7 +117,7 @@ foss_imports_0414 <- read.csv('foss_imports_04-14.csv') %>%
 # combine data (stack)
 foss_imports <- bind_rows(foss_imports_0414, foss_imports_1524)
 
-# Processed Products -----------------------------------------------------------
+# Processed Products & Species Metadata ----------------------------------------
 # read csv's
 foss_pp_1523 <- read.csv('foss_pp_15-23.csv') %>%
   setNames(.[1, ]) %>%
@@ -129,6 +131,12 @@ foss_pp_0414 <- read.csv('foss_pp_04-14.csv') %>%
 
 # combine data (stack)
 foss_pp <- bind_rows(foss_pp_0414, foss_pp_1523)
+
+# read csv of Species metadata
+species_metadata <- read.csv('Assessment_Summary_Data.csv') %>%
+  rename_with( ~ toupper(gsub('.', '_', .x, fixed = T))) %>%
+  rename(TSN = ITIS_TAXON_SERIAL_NUMBER) %>%
+  mutate(COMMON_NAME = toupper(COMMON_NAME))
 
 # Commercial Landings ----------------------------------------------------------
 # read csv's
@@ -176,7 +184,7 @@ file_name <- paste0('seafood_trade_data_pull_',
 # create the file
   # NOTE: add new data to this list upon creation in this script
 save(list = c('foss_exports', 'foss_imports', 'foss_pp', 'def_index',
-              'species_ref', 'foss_com_landings'),
+              'species_ref', 'foss_com_landings', 'species_metadata'),
      file = file_name)
 
 # upload to google drive


### PR DESCRIPTION
THIS ISSUE IS NOT RESOLVED.

This pull does NOT resolve the issue tied to this branch. Contained in this pull request instead is simple data pulls of commercial landings data derived from FOSS and a potentially helpful dataset of metadata for some commercially landed species. 

This issue is not resolved in this pull for some reasons that ultimately lend to the problem that combining commercial landings data and processed products data (as derived from FOSS) is difficult. For instance, the species names described in processed products data differ in presentation than commercial landings data. Processed products present common names in conventional language (e.g. 'ALBACORE TUNA', 'CHINOOK SALMON'). Commercial landings data present species with generic common name first (e.g. 'TUNA') followed by a comma and a more specific common name thereafter (e.g., ', ALBACORE'; in totality: "TUNA, ALBACORE"). The only shared data among processed products data and commercial landings data are the species' names, thus these differences in approach must be reconciled for them to be efficiently, and properly, joined. While commercial landings does provide TSN (Taxonomic Serial Number) with their data which would be a preferred key to join tables on, TSN is unavailable for processed products data unless provided from an outside (of this project) data source. This pull includes a potential dataset for this purpose, however this dataset is presently insufficient for this purpose as some species are not properly formatted in name (which would be necessary to attach these TSNs efficiently to the PP data; e.g. 'PACIFIC POLLOCK' and 'WALLEYE POLLOCK').

It is important to compare commercial landings data with processed products data to understand where domestic landings are processed (either domestically or abroad). This issue will be reposted for later consideration.