### PR TITLE
24 develop a draft of a shiny application tool

### DIFF
--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -185,15 +185,16 @@ ui <- fluidPage(
                          'Salmon', 'Scallops', 'Shrimp', 'Tuna')
            ),
   tabsetPanel(
-             tabPanel('Trade Balance',
+             tabPanel('Trade Balance (Value)',
                       plotOutput('balance')
                       ),
-             tabPanel('Export Volume',
-                      plotOutput('exp_volume')
+             tabPanel('Trade Volume',
+                      fluidRow(
+                        plotOutput('exp_volume')
                       ),
-             tabPanel('Import Volume',
-                      plotOutput('imp_volume')
-                      )
+                      fluidRow(
+                        plotOutput('imp_volume')
+                      )),
              )
            )
 
@@ -201,15 +202,18 @@ ui <- fluidPage(
 server <- function(input, output, session) {
   
   output$balance <- renderPlot({
+    req(input$species != '')
     plot_trade(summarize_yr_spp(trade_data, input$species), 'BALANCE')
   })
   
   output$exp_volume <- renderPlot({
+    req(input$species != '')
     plot_trade(summarize_yr_spp(trade_data, input$species), 'VOLUME', 
                export = T)
   })
   
   output$imp_volume <- renderPlot({
+    req(input$species != '')
     plot_trade(summarize_yr_spp(trade_data, input$species), 'VOLUME',
                import = T)
   })


### PR DESCRIPTION
A rough, simple draft of a shiny application tool is contained in this pull. The application is minimal intentionally, only displaying figures of trade volume and balance based on designated species inputs. While more could be added, the purpose of this issue was to provide a 'proof of concept' of a shiny tool to visualize and interact with the trade data. 

Future developments to the shiny application could include but are not limited to:
- Displaying data with mouse hovering over plot
- adding advanced trade metrics
- Using cards to divide displays for organization
- Adding theme, color, font, etc.
- Increasing species available to index by
- Allowing comparison of species trade metrics
- Maps by U.S. customs district and world trade