### PR TITLE
34 expand listed species for filtering

### DIFF
--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -28,6 +28,8 @@ load('seafood_trade_data_munge_04_30_25.RData')
   # found in the hierarchy
 ecat_list <- com_landings %>%
   select(ECOLOGICAL_CATEGORY) %>%
+com_landings <- com_landings %>%
+  filter(CONFIDENTIALITY == 'Public')
   distinct() %>%
   mutate(ECOLOGICAL_CATEGORY = str_to_title(ECOLOGICAL_CATEGORY)) %>%
   pull()

--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -1711,8 +1711,7 @@ server <- function(input, output, session) {
   # filter_1 is always present in the sidebar
   output$filter_1 <- renderUI({
     # grab all ecological categories
-    ecol_cats <- c('All Species', com_landings %>% 
-                     filter(CONFIDENTIALITY != 'Confidential') %>%
+    ecol_cats <- c('All Species', categorization_matrix %>%
                      select(ECOLOGICAL_CATEGORY) %>%
                      distinct() %>%
                      # remove NA category
@@ -1721,6 +1720,7 @@ server <- function(input, output, session) {
                      mutate(ECOLOGICAL_CATEGORY = 
                               str_to_title(ECOLOGICAL_CATEGORY)) %>%
                      pull())
+    
     selectInput('ecol_cat', 'Choose a Category', ecol_cats)
     
   })
@@ -1731,7 +1731,7 @@ server <- function(input, output, session) {
     # req prevents anything from being run if ecol_cat is not specified
     req(input$ecol_cat != 'All Species')
     # grab all species categories for the selected ecological category
-    species_cats <- c('All Species', com_landings %>%
+    species_cats <- c('All Species', categorization_matrix %>%
                         filter_species(input$ecol_cat) %>%
                         select(SPECIES_CATEGORY) %>%
                         distinct() %>%
@@ -1741,6 +1741,7 @@ server <- function(input, output, session) {
                         mutate(SPECIES_CATEGORY = 
                                  str_to_title(SPECIES_CATEGORY)) %>%
                         pull())
+    
     selectInput('species_cat', 'Choose a Secondary Category', species_cats)
   })
   
@@ -1751,16 +1752,18 @@ server <- function(input, output, session) {
       # are not specified
     req(input$species_cat != 'All Species' & input$ecol_cat != 'All Species')
     # grab all species groups for the selected species category
-    species_groups <- c('All Species', com_landings %>%
+    species_groups <- c('All Species', categorization_matrix %>%
+                          filter_species(input$ecol_cat) %>%
                           filter_species(input$species_cat) %>%
                           select(SPECIES_GROUP) %>%
                           distinct() %>%
                           # remove NA category
                           filter(!is.na(SPECIES_GROUP)) %>%
                           # display strings as titles (first letter capitalized)
-                          mutate(SPECIES_GROUP = 
+                          mutate(SPECIES_GROUP =
                                    str_to_title(SPECIES_GROUP)) %>%
                           pull())
+    
     selectInput('species_grp', 'Choose a Group', species_groups)
   })
   
@@ -1773,7 +1776,9 @@ server <- function(input, output, session) {
           input$species_cat != 'All Species' & 
           input$ecol_cat != 'All Species')
     # grab all species names for the selected species group
-    species_names <- c('All Species', com_landings %>%
+    species_names <- c('All Species', categorization_matrix %>%
+                         filter_species(input$ecol_cat) %>%
+                         filter_species(input$species_cat) %>%
                          filter_species(input$species_grp) %>%
                          select(SPECIES_NAME) %>%
                          distinct() %>%
@@ -1782,6 +1787,7 @@ server <- function(input, output, session) {
                          # display strings as titles (first letter capitalized)
                          mutate(SPECIES_NAME = str_to_title(SPECIES_NAME)) %>%
                          pull())
+    
     selectInput('species_name', 'Choose a Species', species_names)
   })
   

--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -23,6 +23,7 @@ source("nmfs_cols.R")
 # Pull Data (most recent version)
 load('seafood_trade_data_munge_04_30_25.RData')
 
+# filter out confidential data (no data contained therein)
 com_landings <- com_landings %>%
   filter(CONFIDENTIALITY == 'Public')
 
@@ -129,6 +130,7 @@ filter_species <- function(data, species) {
   # species is a character vector of a species of interest 
     # (e.g., 'Albacore Tuna')
   
+  # if All Species is entered, no filtering occurs, original data returned
   if(species == 'All Species') {
     return(data)
   }
@@ -1753,6 +1755,8 @@ server <- function(input, output, session) {
     req(input$species_cat != 'All Species' & input$ecol_cat != 'All Species')
     # grab all species groups for the selected species category
     species_groups <- c('All Species', categorization_matrix %>%
+                          # filter for both previous inputs to only show terms
+                            # related to previous filtering
                           filter_species(input$ecol_cat) %>%
                           filter_species(input$species_cat) %>%
                           select(SPECIES_GROUP) %>%
@@ -1777,6 +1781,8 @@ server <- function(input, output, session) {
           input$ecol_cat != 'All Species')
     # grab all species names for the selected species group
     species_names <- c('All Species', categorization_matrix %>%
+                         # filter for all previous inputs so presented terms 
+                          # only reflect those within selected filters
                          filter_species(input$ecol_cat) %>%
                          filter_species(input$species_cat) %>%
                          filter_species(input$species_grp) %>%
@@ -1923,6 +1929,16 @@ server <- function(input, output, session) {
   
   # identifies which species is the next highest level based on if the 
     # selected category is not available from available trade data
+  # operates by determining which level contains 'All Species'. For that level,
+    # it will unfilter to the next two levels up (because, if species name is
+    # 'All Species', species group was last selected, which means there is no
+    # data for that species group, thus we must unfilter back to species cat,
+    # which is two levels up from species name).
+  # If species cat is 'All Species', then there is no data for ecol cat, which
+    # means we must unfilter back up to All Species (i.e. no filter)
+  # If species name has a selection, then we only unfilter to species group, 
+    # because there must have been data for that species group to have selected
+    # a species name
   unfilter_species_trade <- reactive({
     req(input$trade_button == T)
     ifelse(input$species_cat == 'All Species', 'All Species',
@@ -1942,18 +1958,34 @@ server <- function(input, output, session) {
            unfilter_species_trade())
   })
   
+  # progressive filter applied to data such that plots accurately reflect all
+    # inputted species selections
+  # operates with several if statements that evaluate which filters should be
+    # applied to the data. There are instances where several of the conditions
+    # will be met, thus filtering the data several times. This is fine, because
+    # each if statement overwrites 'new_data', thus only the last met condition
+    # will apply to the outputted data
   trade_filtered <- reactive({
+    # first filter data for the selected ecol_cat
+      # (this will work if 'all species' is selected (default) bc filter_species
+      # accounts for that input)
     new_data <- trade_data %>%
       filter_species(input$ecol_cat)
     
+    # It will apply the next inputted filter only if there is an input for that
+      # filter AND if the selected filter is present in the trade data at that
+      # level (this protects against the ifelse breaking)
     if(species_selection_trade() %in% 
        trade_categorization_matrix$SPECIES_CATEGORY &
        !(is.null(input$species_cat))) {
       
+      # apply filter for both selected inputs
       new_data <- trade_data %>%
         filter_species(input$ecol_cat) %>%
         filter_species(input$species_cat)
       
+      # if the trade button is inputted, replace data with only one filter
+        # applied
       if(input$trade_button == T) {
         new_data <- trade_data %>%
           filter_species(input$ecol_cat)
@@ -2147,6 +2179,7 @@ server <- function(input, output, session) {
   
   # identifies which species is the next highest level based on if the 
     # selected category is not available from available landings data 
+  # see notes above 'unfilter_species_trade'
   unfilter_species_landings <- reactive({
     req(input$landings_button == T)
     ifelse(input$species_cat == 'All Species', 'All Species',
@@ -2166,6 +2199,7 @@ server <- function(input, output, session) {
            unfilter_species_landings())
   })
   
+  # see notes above and within trade_filtered
   landings_filtered <- reactive({
     new_data <- com_landings %>%
       filter_species(input$ecol_cat)
@@ -2279,6 +2313,7 @@ server <- function(input, output, session) {
   
   # identifies which species is the next highest level based on if the 
     # selected category is not available from available production data 
+  # see notes above 'unfilter_species_trade'
   unfilter_species_products <- reactive({
     req(input$products_button == T)
     ifelse(input$species_cat == 'All Species', 'All Species',
@@ -2298,6 +2333,7 @@ server <- function(input, output, session) {
            unfilter_species_products())
   })
   
+  # see notes above and within trade_filtered
   products_filtered <- reactive({
     new_data <- pp_data %>%
       filter_species(input$ecol_cat)

--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -2000,7 +2000,7 @@ server <- function(input, output, session) {
   # creates trade data
   trade_df <- reactive({
     summarize_trade_yr_spp(
-      trade_data,
+      trade_filtered(),
       species_selection_trade()
       )
     })
@@ -2231,7 +2231,7 @@ server <- function(input, output, session) {
   # creates landings data
   landings_df <- reactive({
     summarize_landings_yr_spp(
-      com_landings,
+      landings_filtered(),
       species_selection_landings())
     })
   
@@ -2362,7 +2362,7 @@ server <- function(input, output, session) {
   # creates processed products data
   pp_df <- reactive({
     summarize_pp_yr_spp(
-      pp_data,
+      products_filtered(),
       species_selection_products())
     })
   

--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -23,16 +23,17 @@ source("nmfs_cols.R")
 # Pull Data (most recent version)
 load('seafood_trade_data_munge_04_30_25.RData')
 
-# Create list of terms for each level of organization hierarchy
-  # these lists will be used to determine where a provided species input is 
-  # found in the hierarchy
-ecat_list <- com_landings %>%
-  select(ECOLOGICAL_CATEGORY) %>%
 com_landings <- com_landings %>%
   filter(CONFIDENTIALITY == 'Public')
+
+# create matrix of all categorization terms available in the data
+categorization_matrix <- bind_rows(trade_data, com_landings, pp_data) %>%
+  select(SPECIES_NAME, SPECIES_GROUP, 
+         SPECIES_CATEGORY, ECOLOGICAL_CATEGORY) %>%
+  group_by(SPECIES_NAME, SPECIES_GROUP, 
+           SPECIES_CATEGORY, ECOLOGICAL_CATEGORY) %>%
   distinct() %>%
-  mutate(ECOLOGICAL_CATEGORY = str_to_title(ECOLOGICAL_CATEGORY)) %>%
-  pull()
+  ungroup()
 
 scat_list <- com_landings %>%
   select(SPECIES_CATEGORY) %>%

--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -1855,7 +1855,7 @@ server <- function(input, output, session) {
     req(input$search_term != '')
     # set string to title to match data formatting
     # pull all ecological categories matching the term (there can be multiple)
-    term <- str_to_title(as.character(com_landings %>%
+    term <- str_to_title(as.character(categorization_matrix %>%
                            filter_species(input$search_term) %>%
                            select(ECOLOGICAL_CATEGORY) %>%
                            distinct() %>%
@@ -1876,7 +1876,7 @@ server <- function(input, output, session) {
     req(input$search_term %in% scat_list |
           input$search_term %in% sgrp_list |
           input$search_term %in% sname_list)
-    term <- str_to_title(as.character(com_landings %>%
+    term <- str_to_title(as.character(categorization_matrix %>%
                                         filter_species(input$search_term) %>%
                                         select(SPECIES_CATEGORY) %>%
                                         distinct() %>%
@@ -1890,7 +1890,7 @@ server <- function(input, output, session) {
     req(input$search_term != '')
     req(input$search_term %in% sgrp_list |
           input$search_term %in% sname_list)
-    term <- str_to_title(as.character(com_landings %>%
+    term <- str_to_title(as.character(categorization_matrix %>%
                                         filter_species(input$search_term) %>%
                                         select(SPECIES_GROUP) %>%
                                         distinct() %>%
@@ -1903,7 +1903,7 @@ server <- function(input, output, session) {
   output$search_term_sname <- renderText({
     req(input$search_term != '')
     req(input$search_term %in% sname_list)
-    term <- str_to_title(as.character(com_landings %>%
+    term <- str_to_title(as.character(categorization_matrix %>%
                                         filter_species(input$search_term) %>%
                                         select(SPECIES_NAME) %>%
                                         distinct() %>%

--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -129,6 +129,10 @@ filter_species <- function(data, species) {
   # species is a character vector of a species of interest 
     # (e.g., 'Albacore Tuna')
   
+  if(species == 'All Species') {
+    return(data)
+  }
+  
   # species are organized in a hierarhcy of four levels:
     # ecological category (e.g., 'Large Pelagics')
     # species category (e.g., 'Tunas')

--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -35,23 +35,33 @@ categorization_matrix <- bind_rows(trade_data, com_landings, pp_data) %>%
   distinct() %>%
   ungroup()
 
-scat_list <- com_landings %>%
-  select(SPECIES_CATEGORY) %>%
+# create matrix of all trade categorization terms available in the data
+trade_categorization_matrix <- trade_data %>%
+  select(SPECIES_NAME, SPECIES_GROUP, 
+         SPECIES_CATEGORY, ECOLOGICAL_CATEGORY) %>%
+  group_by(SPECIES_NAME, SPECIES_GROUP, 
+           SPECIES_CATEGORY, ECOLOGICAL_CATEGORY) %>%
   distinct() %>%
-  mutate(SPECIES_CATEGORY = str_to_title(SPECIES_CATEGORY)) %>%
-  pull()
+  ungroup()
 
-sgrp_list <- com_landings %>%
-  select(SPECIES_GROUP) %>%
+# create matrix of all landings categorization terms available in the data
+landings_categorization_matrix <- com_landings %>%
+  select(SPECIES_NAME, SPECIES_GROUP,
+         SPECIES_CATEGORY, ECOLOGICAL_CATEGORY) %>%
+  group_by(SPECIES_NAME, SPECIES_GROUP,
+           SPECIES_CATEGORY, ECOLOGICAL_CATEGORY) %>%
   distinct() %>%
-  mutate(SPECIES_GROUP = str_to_title(SPECIES_GROUP)) %>%
-  pull()
+  ungroup()
 
-sname_list <- com_landings %>%
-  select(SPECIES_NAME) %>%
+# create matrix of all products categorization terms available in the data
+products_categorization_matrix <- pp_data %>%
+  select(SPECIES_NAME, SPECIES_GROUP,
+         SPECIES_CATEGORY, ECOLOGICAL_CATEGORY) %>%
+  group_by(SPECIES_NAME, SPECIES_GROUP,
+           SPECIES_CATEGORY, ECOLOGICAL_CATEGORY) %>%
   distinct() %>%
-  mutate(SPECIES_NAME = str_to_title(SPECIES_NAME)) %>%
-  pull()
+  ungroup()
+
 
 # list of all categorizations available in trade data
 trade_terms <- c('All Species',

--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -1819,38 +1819,34 @@ server <- function(input, output, session) {
   updateSelectizeInput(session = session,
                        'search_term',
                        choices = 
-                         c('', sort(c(com_landings %>%
-                                  filter(CONFIDENTIALITY != 'Confidential') %>%
-                                  select(ECOLOGICAL_CATEGORY) %>%
-                                  distinct() %>%
-                                  filter(!is.na(ECOLOGICAL_CATEGORY)) %>%
-                                  mutate(ECOLOGICAL_CATEGORY = 
-                                           str_to_title(ECOLOGICAL_CATEGORY)) %>%
-                                  pull(),
-                                com_landings %>%
-                                  filter(CONFIDENTIALITY != 'Confidential') %>%
-                                  select(SPECIES_CATEGORY) %>%
-                                  distinct() %>%
-                                  filter(!is.na(SPECIES_CATEGORY)) %>%
-                                  mutate(SPECIES_CATEGORY = 
-                                           str_to_title(SPECIES_CATEGORY)) %>%
-                                  pull(),
-                                com_landings %>%
-                                  filter(CONFIDENTIALITY != 'Confidential') %>%
-                                  select(SPECIES_GROUP) %>%
-                                  distinct() %>%
-                                  filter(!is.na(SPECIES_GROUP)) %>%
-                                  mutate(SPECIES_GROUP = 
-                                           str_to_title(SPECIES_GROUP)) %>%
-                                  pull(),
-                                com_landings %>%
-                                  filter(CONFIDENTIALITY != 'Confidential') %>%
-                                  select(SPECIES_NAME) %>%
-                                  distinct() %>%
-                                  filter(!is.na(SPECIES_NAME)) %>%
-                                  mutate(SPECIES_NAME = 
-                                           str_to_title(SPECIES_NAME)) %>%
-                                  pull()))),
+                         c('', sort(c(categorization_matrix %>%
+                                        select(ECOLOGICAL_CATEGORY) %>%
+                                        distinct() %>%
+                                        filter(!is.na(ECOLOGICAL_CATEGORY)) %>%
+                                        mutate(ECOLOGICAL_CATEGORY = 
+                                                 str_to_title(ECOLOGICAL_CATEGORY)) %>%
+                                        pull(),
+                                      categorization_matrix %>%
+                                        select(SPECIES_CATEGORY) %>%
+                                        distinct() %>%
+                                        filter(!is.na(SPECIES_CATEGORY)) %>%
+                                        mutate(SPECIES_CATEGORY = 
+                                                 str_to_title(SPECIES_CATEGORY)) %>%
+                                        pull(),
+                                      categorization_matrix %>%
+                                        select(SPECIES_GROUP) %>%
+                                        distinct() %>%
+                                        filter(!is.na(SPECIES_GROUP)) %>%
+                                        mutate(SPECIES_GROUP = 
+                                                 str_to_title(SPECIES_GROUP)) %>%
+                                        pull(),
+                                      categorization_matrix %>%
+                                        select(SPECIES_NAME) %>%
+                                        distinct() %>%
+                                        filter(!is.na(SPECIES_NAME)) %>%
+                                        mutate(SPECIES_NAME = 
+                                                 str_to_title(SPECIES_NAME)) %>%
+                                        pull()))),
                        server = T)
   
   # Display search term categories for user to filter by

--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -1941,6 +1941,61 @@ server <- function(input, output, session) {
     ifelse(species_selected() %in% trade_terms, species_selected(),
            unfilter_species_trade())
   })
+  
+  trade_filtered <- reactive({
+    new_data <- trade_data %>%
+      filter_species(input$ecol_cat)
+    
+    if(species_selection_trade() %in% 
+       trade_categorization_matrix$SPECIES_CATEGORY &
+       !(is.null(input$species_cat))) {
+      
+      new_data <- trade_data %>%
+        filter_species(input$ecol_cat) %>%
+        filter_species(input$species_cat)
+      
+      if(input$trade_button == T) {
+        new_data <- trade_data %>%
+          filter_species(input$ecol_cat)
+      }
+    }
+    
+    if(species_selection_trade() %in% 
+       trade_categorization_matrix$SPECIES_GROUP &
+       !(is.null(input$species_grp))) {
+      
+      new_data <- trade_data %>%
+        filter_species(input$ecol_cat) %>%
+        filter_species(input$species_cat) %>%
+        filter_species(input$species_grp)
+      
+      if(input$trade_button == T) {
+        new_data <- trade_button %>%
+          filter_species(input$ecol_cat) %>%
+          filter_species(input$species_cat)
+      }
+    }
+    
+    if(species_selection_trade() %in% 
+       trade_categorization_matrix$SPECIES_NAME &
+       !(is.null(input$species_name))) {
+      
+      new_data <- trade_data %>%
+        filter_species(input$ecol_cat) %>%
+        filter_species(input$species_cat) %>%
+        filter_species(input$species_grp) %>%
+        filter_species(input$species_name)
+      
+      if(input$trade_button == T) {
+        new_data <- trade_data %>%
+          filter_species(input$ecol_cat) %>%
+          filter_species(input$species_cat) %>%
+          filter_species(input$species_grp)
+      }
+    }
+    
+    new_data
+  })
 
   # creates trade data
   trade_df <- reactive({
@@ -2111,6 +2166,62 @@ server <- function(input, output, session) {
            unfilter_species_landings())
   })
   
+  landings_filtered <- reactive({
+    new_data <- com_landings %>%
+      filter_species(input$ecol_cat)
+    
+    if(species_selection_landings() %in% 
+       landings_categorization_matrix$SPECIES_CATEGORY &
+       !(is.null(input$species_cat))) {
+      
+      new_data <- com_landings %>%
+        filter_species(input$ecol_cat) %>%
+        filter_species(input$species_cat)
+      
+      if(input$landings_button == T) {
+        new_data <- com_landings %>%
+          filter_species(input$ecol_cat)
+      }
+    }
+    
+    if(species_selection_landings() %in% 
+       landings_categorization_matrix$SPECIES_GROUP &
+       !(is.null(input$species_grp))) {
+      
+      new_data <- com_landings %>%
+        filter_species(input$ecol_cat) %>%
+        filter_species(input$species_cat) %>%
+        filter_species(input$species_grp)
+      
+      if(input$landings_button == T) {
+        new_data <- com_landings %>%
+          filter_species(input$ecol_cat) %>%
+          filter_species(input$species_cat)
+      }
+      
+    }
+    
+    if(species_selection_landings() %in% 
+       landings_categorization_matrix$SPECIES_NAME &
+       !(is.null(input$species_name))) {
+      
+      new_data <- com_landings %>%
+        filter_species(input$ecol_cat) %>%
+        filter_species(input$species_cat) %>%
+        filter_species(input$species_grp) %>%
+        filter_species(input$species_name)
+      
+      if(input$landings_button == T) {
+        new_data <- com_landings %>%
+          filter_species(input$ecol_cat) %>%
+          filter_species(input$species_cat) %>%
+          filter_species(input$species_grp)
+      }
+    }
+    
+    new_data
+  })
+  
   # validation reactive; displays message if species is not found in landings data
   landings_data_validation <- reactive({
     validate(need(try(species_selection_landings() %in% landings_terms),
@@ -2185,6 +2296,61 @@ server <- function(input, output, session) {
   species_selection_products <- reactive({
     ifelse(species_selected() %in% pp_terms, species_selected(),
            unfilter_species_products())
+  })
+  
+  products_filtered <- reactive({
+    new_data <- pp_data %>%
+      filter_species(input$ecol_cat)
+    
+    if(species_selection_products() %in% 
+       products_categorization_matrix$SPECIES_CATEGORY &
+       !(is.null(input$species_cat))) {
+      
+      new_data <- pp_data %>%
+        filter_species(input$ecol_cat) %>%
+        filter_species(input$species_cat)
+      
+      if(input$products_button == T) {
+        new_data <- pp_data %>%
+          filter_species(input$ecol_cat)
+      }
+    }
+    
+    if(species_selection_products() %in% 
+       products_categorization_matrix$SPECIES_GROUP &
+       !(is.null(input$species_grp))) {
+      
+      new_data <- pp_data %>%
+        filter_species(input$ecol_cat) %>%
+        filter_species(input$species_cat) %>%
+        filter_species(input$species_grp)
+      
+      if(input$products_button == T) {
+        new_data <- pp_data %>%
+          filter_species(input$ecol_cat) %>%
+          filter_species(input$species_cat)
+      }
+    }
+    
+    if(species_selection_products() %in% 
+       products_categorization_matrix$SPECIES_NAME &
+       !(is.null(input$species_name))) {
+      
+      new_data <- pp_data %>%
+        filter_species(input$ecol_cat) %>%
+        filter_species(input$species_cat) %>%
+        filter_species(input$species_grp) %>%
+        filter_species(input$species_name)
+      
+      if(input$products_button == T) {
+        new_data <- pp_data %>%
+          filter_species(input$ecol_cat) %>%
+          filter_species(input$species_cat) %>%
+          filter_species(input$species_grp)
+      }
+    }
+    
+    new_data
   })
   
   # validation reactive; outputs message if species is not found in production data

--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -103,7 +103,11 @@ trade_terms <- c('All Species',
                  str_to_title(unique(trade_data$SPECIES_NAME)))
 
 # list of all categorizations available in landings data
-landings_terms <- c('All Species', ecat_list, scat_list, sgrp_list, sname_list)
+landings_terms <- c('All Species',
+                    str_to_title(unique(com_landings$ECOLOGICAL_CATEGORY)),
+                    str_to_title(unique(com_landings$SPECIES_CATEGORY)),
+                    str_to_title(unique(com_landings$SPECIES_GROUP)),
+                    str_to_title(unique(com_landings$SPECIES_NAME)))
 
 # list of all categorizations available in production data
 pp_terms <- c('All Species',

--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -62,6 +62,38 @@ products_categorization_matrix <- pp_data %>%
   distinct() %>%
   ungroup()
 
+# Create list of terms for each level of organization hierarchy
+  # these lists will be used to determine where a provided species input is 
+  # found in the hierarchy
+ecat_list <- unique(categorization_matrix %>%
+                      select(ECOLOGICAL_CATEGORY) %>%
+                      distinct() %>%
+                      filter(!is.na(ECOLOGICAL_CATEGORY)) %>%
+                      mutate(ECOLOGICAL_CATEGORY = 
+                               str_to_title(ECOLOGICAL_CATEGORY)) %>%
+                      pull()) 
+
+scat_list <- unique(categorization_matrix %>%
+                      select(SPECIES_CATEGORY) %>%
+                      distinct() %>%
+                      filter(!is.na(SPECIES_CATEGORY)) %>%
+                      mutate(SPECIES_CATEGORY = 
+                               str_to_title(SPECIES_CATEGORY)) %>%
+                      pull())
+
+sgrp_list <- unique(categorization_matrix %>%
+                      select(SPECIES_GROUP) %>%
+                      distinct() %>%
+                      filter(!is.na(SPECIES_GROUP)) %>%
+                      mutate(SPECIES_GROUP = str_to_title(SPECIES_GROUP)) %>%
+                      pull())
+
+sname_list <- unique(categorization_matrix %>%
+                       select(SPECIES_NAME) %>%
+                       distinct() %>%
+                       filter(!is.na(SPECIES_NAME)) %>%
+                       mutate(SPECIES_NAME = str_to_title(SPECIES_NAME)) %>%
+                       pull())
 
 # list of all categorizations available in trade data
 trade_terms <- c('All Species',

--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -1925,10 +1925,10 @@ server <- function(input, output, session) {
     # selected category is not available from available trade data
   unfilter_species_trade <- reactive({
     req(input$trade_button == T)
-    ifelse(input$species_name != '', input$species_grp,
-           ifelse(input$species_group != '', input$species_cat,
-                  ifelse(input$species_cat != '', input$ecol_cat,
-                         NA)))
+    ifelse(input$species_cat == 'All Species', 'All Species',
+           ifelse(input$species_grp == 'All Species', input$ecol_cat,
+                  ifelse(input$species_name == 'All Species', input$species_cat,
+                         ifelse(input$species_name != 'All Species', input$species_grp))))
   })
   
   # determines if the selected species OR the next highest level of categorization
@@ -2094,10 +2094,10 @@ server <- function(input, output, session) {
     # selected category is not available from available landings data 
   unfilter_species_landings <- reactive({
     req(input$landings_button == T)
-    ifelse(input$species_name != '', input$species_grp,
-           ifelse(input$species_group != '', input$species_cat,
-                  ifelse(input$species_cat != '', input$ecol_cat,
-                         NA)))
+    ifelse(input$species_cat == 'All Species', 'All Species',
+           ifelse(input$species_grp == 'All Species', input$ecol_cat,
+                  ifelse(input$species_name == 'All Species', input$species_cat,
+                         ifelse(input$species_name != 'All Species', input$species_grp))))
   })
   
   # determines if the selected species OR the next highest level of categorization
@@ -2170,10 +2170,10 @@ server <- function(input, output, session) {
     # selected category is not available from available production data 
   unfilter_species_products <- reactive({
     req(input$products_button == T)
-    ifelse(input$species_name != '', input$species_grp,
-           ifelse(input$species_group != '', input$species_cat,
-                  ifelse(input$species_cat != '', input$ecol_cat,
-                         NA)))
+    ifelse(input$species_cat == 'All Species', 'All Species',
+           ifelse(input$species_grp == 'All Species', input$ecol_cat,
+                  ifelse(input$species_name == 'All Species', input$species_cat,
+                         ifelse(input$species_name != 'All Species', input$species_grp))))
   })
   
   # determines if the selected species OR the next highest level of categorization


### PR DESCRIPTION
This pull achieves expanding the listed species for users to filter by. Prior, the listed species were only those included in commercial landings data, because that data included the greatest diversity of species of all represented datasets. Now, all dataset species are represented to account for species that are not caught but are traded (i.e., those not appearing in commercial landings). 
A secondary issue arose during this effort. Some terms are not unique to their prior levels (i.e., reef fishes can be large and small coastals, which are distinct ecological categories). This would thus present data inaccurately where, in the above example, if a user selected large coastals and reef fishes, the presented data would be identical to selecting small coastals and reef fishes. The solution lies in creating a reactive expression with a progressive filter that outputs data based on selected inputs. Effectively, the reactive expression filters the dataset with each selected input in a progressive manner, first filtering for the selected ecological category (the highest level), then filtering for the selected species category, and so on. Unfiltered buttons created previously now apply this functioning, and the data represented accurately reflect all applied filters. 