### PR TITLE
38 change unfilter to last available input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ rsconnect/
 # all HMS plot
 *HMS_Plots/
 HMS_Analysis.R
+groundfish_analysis.R
+groundfish_volume_ratio.png

--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -2015,10 +2015,28 @@ server <- function(input, output, session) {
     # a species name
   unfilter_species_trade <- reactive({
     req(input$trade_button == T)
-    ifelse(input$species_cat == 'All Species', 'All Species',
-           ifelse(input$species_grp == 'All Species', input$ecol_cat,
-                  ifelse(input$species_name == 'All Species', input$species_cat,
-                         ifelse(input$species_name != 'All Species', input$species_grp))))
+    
+    if(input$species_cat == 'All Species') {
+      ifelse(input$ecol_cat %in% trade_terms(), input$ecol_cat,
+             'All Species')
+    } else if(input$species_grp == 'All Species') {
+      ifelse(input$species_cat %in% trade_terms(), input$species_cat,
+             ifelse(input$ecol_cat %in% trade_terms(), input$ecol_cat,
+                    'All Species'))
+    } else if(input$species_name == 'All Species') {
+      ifelse(input$species_grp %in% trade_terms(), input$species_grp,
+             ifelse(input$species_cat %in% trade_terms(), input$species_cat,
+                    ifelse(input$ecol_cat %in% trade_terms(), input$ecol_cat,
+                           'All Species')))
+    } else if(input$species_name != 'All Species') {
+      ifelse(input$species_name %in% trade_terms(), input$species_name,
+             ifelse(input$species_grp %in% trade_terms(), input$species_grp,
+                    ifelse(input$species_cat %in% trade_terms(), input$species_cat,
+                           ifelse(input$ecol_cat %in% trade_terms(), input$ecol_cat,
+                                  'All Species'))))
+    }
+    
+    
   })
   
   # determines if the selected species OR the next highest level of categorization
@@ -2345,10 +2363,26 @@ server <- function(input, output, session) {
   # see notes above 'unfilter_species_trade'
   unfilter_species_landings <- reactive({
     req(input$landings_button == T)
-    ifelse(input$species_cat == 'All Species', 'All Species',
-           ifelse(input$species_grp == 'All Species', input$ecol_cat,
-                  ifelse(input$species_name == 'All Species', input$species_cat,
-                         ifelse(input$species_name != 'All Species', input$species_grp))))
+    
+    if(input$species_cat == 'All Species') {
+      ifelse(input$ecol_cat %in% landings_terms(), input$ecol_cat,
+             'All Species')
+    } else if(input$species_grp == 'All Species') {
+      ifelse(input$species_cat %in% landings_terms(), input$species_cat,
+             ifelse(input$ecol_cat %in% landings_terms(), input$ecol_cat,
+                    'All Species'))
+    } else if(input$species_name == 'All Species') {
+      ifelse(input$species_grp %in% landings_terms(), input$species_grp,
+             ifelse(input$species_cat %in% landings_terms(), input$species_cat,
+                    ifelse(input$ecol_cat %in% landings_terms(), input$ecol_cat,
+                           'All Species')))
+    } else if(input$species_name != 'All Species') {
+      ifelse(input$species_name %in% landings_terms(), input$species_name,
+             ifelse(input$species_grp %in% landings_terms(), input$species_grp,
+                    ifelse(input$species_cat %in% landings_terms(), input$species_cat,
+                           ifelse(input$ecol_cat %in% landings_terms(), input$ecol_cat,
+                                  'All Species'))))
+    }
   })
   
   # determines if the selected species OR the next highest level of categorization
@@ -2568,10 +2602,26 @@ server <- function(input, output, session) {
   # see notes above 'unfilter_species_trade'
   unfilter_species_products <- reactive({
     req(input$products_button == T)
-    ifelse(input$species_cat == 'All Species', 'All Species',
-           ifelse(input$species_grp == 'All Species', input$ecol_cat,
-                  ifelse(input$species_name == 'All Species', input$species_cat,
-                         ifelse(input$species_name != 'All Species', input$species_grp))))
+    
+    if(input$species_cat == 'All Species') {
+      ifelse(input$ecol_cat %in% pp_terms(), input$ecol_cat,
+             'All Species')
+    } else if(input$species_grp == 'All Species') {
+      ifelse(input$species_cat %in% pp_terms(), input$species_cat,
+             ifelse(input$ecol_cat %in% pp_terms(), input$ecol_cat,
+                    'All Species'))
+    } else if(input$species_name == 'All Species') {
+      ifelse(input$species_grp %in% pp_terms(), input$species_grp,
+             ifelse(input$species_cat %in% pp_terms(), input$species_cat,
+                    ifelse(input$ecol_cat %in% pp_terms(), input$ecol_cat,
+                           'All Species')))
+    } else if(input$species_name != 'All Species') {
+      ifelse(input$species_name %in% pp_terms(), input$species_name,
+             ifelse(input$species_grp %in% pp_terms(), input$species_grp,
+                    ifelse(input$species_cat %in% pp_terms(), input$species_cat,
+                           ifelse(input$ecol_cat %in% pp_terms(), input$ecol_cat,
+                                  'All Species'))))
+    }
   })
   
   # determines if the selected species OR the next highest level of categorization

--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -1929,7 +1929,12 @@ server <- function(input, output, session) {
     # if a species category was selected, will return all species categories
       # for the selected ecological category in the trade data
     if(cat_index == 'scat') {
-      result <- c(input$ecol_cat,
+      if(toupper(input$ecol_cat) %in% 
+         trade_categorization_matrix$ECOLOGICAL_CATEGORY) {
+        terms <- input$ecol_cat
+      } else {
+        terms <- vector()
+      result <- c(terms,
                   trade_categorization_matrix %>%
                     filter_species(input$ecol_cat) %>%
                     select(SPECIES_CATEGORY) %>%
@@ -1940,7 +1945,19 @@ server <- function(input, output, session) {
     # if a species group was selected, will return all species groups for
       # that species category AND that ecological category in the trade data
     if(cat_index == 'sgrp') {
-      result <- c(input$ecol_cat, input$species_cat, 
+      if(toupper(input$species_cat) %in% (trade_categorization_matrix %>%
+                                          filter_species(input$ecol_cat) %>%
+                                          select(SPECIES_CATEGORY) %>%
+                                          pull())) {
+        terms <- c(input$ecol_cat, input$species_cat)
+      } else if(toupper(input$ecol_cat) %in%
+                trade_categorization_matrix$ECOLOGICAL_CATEGORY) {
+        terms <- input$ecol_cat
+      } else {
+        terms <- vector()
+      }
+      
+      result <- c(terms, 
                   trade_categorization_matrix %>%
                     filter_species(input$ecol_cat) %>%
                     filter_species(input$species_cat) %>%
@@ -1953,7 +1970,25 @@ server <- function(input, output, session) {
       # that species group AND species category AND ecological category in the
       # trade data
     if(cat_index == 'sname') {
-      result <- c(input$ecol_cat, input$species_cat, input$species_grp, 
+      if(toupper(input$species_grp) %in% (trade_categorization_matrix %>%
+                                         filter_species(input$ecol_cat) %>%
+                                         filter_species(input$species_cat) %>%
+                                         select(SPECIES_GROUP) %>%
+                                         pull())) {
+        terms <- c(input$ecol_cat, input$species_cat, input$species_grp)
+      } else if(toupper(input$species_cat) %in% (trade_categorization_matrix %>%
+                                                 filter_species(input$ecol_cat) %>%
+                                                 select(SPECIES_CATEGORY) %>%
+                                                 pull())) {
+        terms <- c(input$ecol_cat, input$species_cat)
+      } else if(toupper(input$ecol_cat) %in% 
+                trade_categorization_matrix$ECOLOGICAL_CATEGORY) {
+        terms <- input$ecol_cat
+      } else {
+        terms <- vector()
+      }
+      
+      result <- c(terms, 
                   trade_categorization_matrix %>%
                     filter_species(input$ecol_cat) %>%
                     filter_species(input$species_cat) %>%
@@ -2236,7 +2271,14 @@ server <- function(input, output, session) {
     }
     
     if(cat_index == 'scat') {
-      result <- c(input$ecol_cat,
+      if(toupper(input$ecol_cat) %in% 
+         landings_categorization_matrix$ECOLOGICAL_CATEGORY) {
+        terms <- input$ecol_cat
+      } else {
+        terms <- vector()
+      }
+      
+      result <- c(terms,
                   landings_categorization_matrix %>%
                     filter_species(input$ecol_cat) %>%
                     select(SPECIES_CATEGORY) %>%
@@ -2245,7 +2287,19 @@ server <- function(input, output, session) {
     }
     
     if(cat_index == 'sgrp') {
-      result <- c(input$ecol_cat, input$species_cat, 
+      if(toupper(input$species_cat) %in% (landings_categorization_matrix %>%
+                                          filter_species(input$ecol_cat) %>%
+                                          select(SPECIES_CATEGORY) %>%
+                                          pull())) {
+        terms <- c(input$ecol_cat, input$species_cat)
+      } else if(toupper(input$ecol_cat) %in%
+                landings_categorization_matrix$ECOLOGICAL_CATEGORY) {
+        terms <- input$ecol_cat
+      } else {
+        terms <- vector()
+      }
+      
+      result <- c(terms, 
                   landings_categorization_matrix %>%
                     filter_species(input$ecol_cat) %>%
                     filter_species(input$species_cat) %>%
@@ -2255,7 +2309,25 @@ server <- function(input, output, session) {
     }
     
     if(cat_index == 'sname') {
-      result <- c(input$ecol_cat, input$species_cat, input$species_grp, 
+      if(toupper(input$species_grp) %in% (landings_categorization_matrix %>%
+                                          filter_species(input$ecol_cat) %>%
+                                          filter_species(input$species_cat) %>%
+                                          select(SPECIES_GROUP) %>%
+                                          pull())) {
+        terms <- c(input$ecol_cat, input$species_cat, input$species_grp)
+      } else if(toupper(input$species_cat) %in% (landings_categorization_matrix %>%
+                                                 filter_species(input$ecol_cat) %>%
+                                                 select(SPECIES_CATEGORY) %>%
+                                                 pull())) {
+        terms <- c(input$ecol_cat, input$species_cat)
+      } else if(toupper(input$ecol_cat) %in% 
+                landings_categorization_matrix$ECOLOGICAL_CATEGORY) {
+        terms <- input$ecol_cat
+      } else {
+        terms <- vector()
+      }
+      
+      result <- c(terms, 
                   landings_categorization_matrix %>%
                     filter_species(input$ecol_cat) %>%
                     filter_species(input$species_cat) %>%
@@ -2422,7 +2494,14 @@ server <- function(input, output, session) {
     }
     
     if(cat_index == 'scat') {
-      result <- c(input$ecol_cat,
+      if(toupper(input$ecol_cat) %in% 
+         products_categorization_matrix$ECOLOGICAL_CATEGORY) {
+        terms <- input$ecol_cat
+      } else {
+        terms <- vector()
+      }
+      
+      result <- c(terms,
                   products_categorization_matrix %>%
                     filter_species(input$ecol_cat) %>%
                     select(SPECIES_CATEGORY) %>%
@@ -2431,7 +2510,19 @@ server <- function(input, output, session) {
     }
     
     if(cat_index == 'sgrp') {
-      result <- c(input$ecol_cat, input$species_cat, 
+      if(toupper(input$species_cat) %in% (products_categorization_matrix %>%
+                                          filter_species(input$ecol_cat) %>%
+                                          select(SPECIES_CATEGORY) %>%
+                                          pull())) {
+        terms <- c(input$ecol_cat, input$species_cat)
+      } else if(toupper(input$ecol_cat) %in%
+                products_categorization_matrix$ECOLOGICAL_CATEGORY) {
+        terms <- input$ecol_cat
+      } else {
+        terms <- vector()
+      }
+      
+      result <- c(terms, 
                   products_categorization_matrix %>%
                     filter_species(input$ecol_cat) %>%
                     filter_species(input$species_cat) %>%
@@ -2441,7 +2532,25 @@ server <- function(input, output, session) {
     }
     
     if(cat_index == 'sname') {
-      result <- c(input$ecol_cat, input$species_cat, input$species_grp, 
+      if(toupper(input$species_grp) %in% (products_categorization_matrix %>%
+                                          filter_species(input$ecol_cat) %>%
+                                          filter_species(input$species_cat) %>%
+                                          select(SPECIES_GROUP) %>%
+                                          pull())) {
+        terms <- c(input$ecol_cat, input$species_cat, input$species_grp)
+      } else if(toupper(input$species_cat) %in% (products_categorization_matrix %>%
+                                                 filter_species(input$ecol_cat) %>%
+                                                 select(SPECIES_CATEGORY) %>%
+                                                 pull())) {
+        terms <- c(input$ecol_cat, input$species_cat)
+      } else if(toupper(input$ecol_cat) %in% 
+                products_categorization_matrix$ECOLOGICAL_CATEGORY) {
+        terms <- input$ecol_cat
+      } else {
+        terms <- vector()
+      }
+      
+      result <- c(terms, 
                   products_categorization_matrix %>%
                     filter_species(input$ecol_cat) %>%
                     filter_species(input$species_cat) %>%

--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -96,6 +96,8 @@ sname_list <- unique(categorization_matrix %>%
                        mutate(SPECIES_NAME = str_to_title(SPECIES_NAME)) %>%
                        pull())
 
+###
+
 # Custom Functions -------------------------------------------------------------
 # stop functions without outputting error message
 stop_quietly <- function() {
@@ -148,7 +150,7 @@ filter_species <- function(data, species) {
   # if species was not found, stop function with message to try a different
     # species input or search for available entries
   if (locate_level == 'UNAVAILABLE') {
-    stop()
+    return(data[-c(1:nrow(data)), ])
   } 
   
   # only runs if species is found

--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -1928,12 +1928,22 @@ server <- function(input, output, session) {
     
     # if a species category was selected, will return all species categories
       # for the selected ecological category in the trade data
+      # We also need to include the previously selected ecological category,
+        # but only if that category exists in the trade data
     if(cat_index == 'scat') {
       if(toupper(input$ecol_cat) %in% 
          trade_categorization_matrix$ECOLOGICAL_CATEGORY) {
         terms <- input$ecol_cat
       } else {
+        # if the category does not exist, create empty vector for functionality
         terms <- vector()
+      }
+      
+      # the output will include the ecological category term (if it exists) and
+        # all species categories that exist within that ecological category
+        # Should the e_cat NOT exist in the trade data, filter_species will 
+          # return an empty data frame, thus trade_terms will be empty, and
+          # 'All Species' will be returned later in unfilter_species_trade()
       result <- c(terms,
                   trade_categorization_matrix %>%
                     filter_species(input$ecol_cat) %>%
@@ -1944,15 +1954,20 @@ server <- function(input, output, session) {
     
     # if a species group was selected, will return all species groups for
       # that species category AND that ecological category in the trade data
+      # We also need to include the previously selected ecological and species
+        # categories but only if they exist in the trade data
     if(cat_index == 'sgrp') {
       if(toupper(input$species_cat) %in% (trade_categorization_matrix %>%
                                           filter_species(input$ecol_cat) %>%
                                           select(SPECIES_CATEGORY) %>%
                                           pull())) {
         terms <- c(input$ecol_cat, input$species_cat)
+        # if they don't exist, then check if ecol_cat exists in the trade data
       } else if(toupper(input$ecol_cat) %in%
                 trade_categorization_matrix$ECOLOGICAL_CATEGORY) {
         terms <- input$ecol_cat
+        # if neither the selected species or e_cat terms exist, returns empty
+          # vector
       } else {
         terms <- vector()
       }
@@ -1969,6 +1984,9 @@ server <- function(input, output, session) {
     # if a species name was selected, will return all species names for
       # that species group AND species category AND ecological category in the
       # trade data
+      # We also need to include the previously selected ecological and species
+        # categories and the species group, but only if they exist in the trade
+        # data
     if(cat_index == 'sname') {
       if(toupper(input$species_grp) %in% (trade_categorization_matrix %>%
                                          filter_species(input$ecol_cat) %>%
@@ -1976,14 +1994,19 @@ server <- function(input, output, session) {
                                          select(SPECIES_GROUP) %>%
                                          pull())) {
         terms <- c(input$ecol_cat, input$species_cat, input$species_grp)
+        # if they don't, check if the selected ecological and species categories
+          # exist in the trade data
       } else if(toupper(input$species_cat) %in% (trade_categorization_matrix %>%
                                                  filter_species(input$ecol_cat) %>%
                                                  select(SPECIES_CATEGORY) %>%
                                                  pull())) {
         terms <- c(input$ecol_cat, input$species_cat)
+        # if they don't, check if the selected ecological category exists in the
+          # trade data
       } else if(toupper(input$ecol_cat) %in% 
                 trade_categorization_matrix$ECOLOGICAL_CATEGORY) {
         terms <- input$ecol_cat
+        # if it doesn't, return empty vector
       } else {
         terms <- vector()
       }
@@ -1998,6 +2021,13 @@ server <- function(input, output, session) {
                     pull())
     }
     
+    # result will thus include any selected terms made by the user ONLY if those
+      # terms exist within their prior filters, and all terms of the last 
+      # selected input. This creates a vector of terms that subsequent reactive
+      # expressions will search through to determine if the last selected input
+      # exists in the trade data. This enables functionality of the unfilter 
+      # button such that, when checked, it will default back to the last 
+      # available term within this result vector
     result
   })
   
@@ -2016,9 +2046,26 @@ server <- function(input, output, session) {
   unfilter_species_trade <- reactive({
     req(input$trade_button == T)
     
+    # determine what the last selected input was. We start from the earliest
+      # possible filter (in this case, species_cat since if ecol_cat == 'All
+      # Species' then no selection was made)
     if(input$species_cat == 'All Species') {
+      # if species_cat == 'All Species', then the user has only inputted 
+        # ecol_cat, which means we only have to check that input
+      # trade_terms, as explained above, includes all previously selected terms
+        # ONLY IF they exist in the trade data, and all available terms within
+        # the previously selected filters (e.g., if the last selected filter was
+        # species group, trade_terms() includes the selected e_cat and 
+        # species_cat terms and all species_grp terms that exist in the data
+        # after filtering for the selected e_cat and species_cat's)
       ifelse(input$ecol_cat %in% trade_terms(), input$ecol_cat,
              'All Species')
+      # Subsequent ifelse terms work backwards from the last selected input
+        # to determine which last selected term exists in the trade data based
+        # on the selected filters. This is such that if a user selected down
+        # to species name, but the last available trade data was from the 
+        # selected ecol_cat term, then selecting the unfilter_button would
+        # display the ecol_cat filtered data for trade plots
     } else if(input$species_grp == 'All Species') {
       ifelse(input$species_cat %in% trade_terms(), input$species_cat,
              ifelse(input$ecol_cat %in% trade_terms(), input$ecol_cat,

--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -1786,7 +1786,7 @@ server <- function(input, output, session) {
                   ''))
     req(!(species_selected() %in% trade_terms()))
     
-    checkboxInput('trade_button', 'Unfilter Trade Plots Up One Level')
+    checkboxInput('trade_button', 'Revert trade data to last available selection')
   })
   
   # creates checkbox to unfilter production up one level
@@ -1797,7 +1797,7 @@ server <- function(input, output, session) {
                   ''))
     req(!(species_selected() %in% pp_terms()))
     
-    checkboxInput('products_button', 'Unfilter Products Plots Up One Level')
+    checkboxInput('products_button', 'Revert products data to last available selection')
   })
   
   # creates checkbox to unfilter landings up one level
@@ -1808,7 +1808,7 @@ server <- function(input, output, session) {
                   ''))
     req(!(species_selected() %in% landings_terms()))
     
-    checkboxInput('landings_button', 'Unfilter Landings Plots Up One Level')
+    checkboxInput('landings_button', 'Revert landings data to last available selection')
   })
   
   # define search bar terms


### PR DESCRIPTION
This pull achieves its goal: when users select inputs that are unavailable for a given dataset, a button appears that tells the user if they check the box the data will revert to the last available selection. This now works as described to the user, as this pull documents changing reactive expressions to accurately perform this task. Specifically, each dataset creates a reactive expression of terms that are available in their data based on the user's selections. If the user selected an ecological category, these terms include all available species category (the next level in the classification hierarchy) terms AND the selected ecological category. As the user continues to make selections, these terms update based on the last selected input. What matters now is that the prior selected inputs made by the user are only included in this list of terms if their selections existed in the dataset. If they did not, then the reactive terms expression would not include the unavailable term. This is important because if the user continues to make selections down the hierarchy after selecting an input that did not exist, the terms expression will only include the last available input. Thus, when they select the 'revert data' button (formerly unfilter), the expression will search for the last available input in the terms expression and filter the data for that term. 

In summary, the user now has the power to display data for any selected input across all datasets. This is because if they make a multiple subsequent selections that do not exist for a given dataset, at minimum the button will revert the data back to default should all selections be unavailable for the dataset.