### PR TITLE
53 hover over plots provides values

### DIFF
--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -3977,6 +3977,1565 @@ server <- function(input, output, session) {
     supply_share_plot()
   })
   
+  # Plot-clicking tooltips -----------------------------------------------------
+  #' *Trade Balance Plot*
+  # Stores data point information and pixel coordinates where user clicked
+  balance_clicked_point <- reactiveVal(NULL)
+  
+  # Handle click events and store clicked point
+  observeEvent(input$balance_plot_click, {
+    
+    click_x <- input$balance_plot_click$x
+    
+    balance_data <- trade_df()
+    
+    balance_data <- balance_data %>%
+      rename(EXPORTS = EXP_VALUE_2024USD_MILLIONS,
+             IMPORTS = IMP_VALUE_2024USD_MILLIONS) %>%
+      select(YEAR, EXPORTS, IMPORTS) %>%
+      # calculate trade balance value
+      mutate(TRADE_BALANCE = EXPORTS - IMPORTS) %>%
+      # pivot longer so there are three groups: exports, imports, and balance
+      pivot_longer(cols = c(EXPORTS, IMPORTS, TRADE_BALANCE)) %>%
+      # factor the column storing the groups
+      mutate(name = as.factor(name))
+    
+    year_levels <- levels(factor(sort(unique(balance_data$YEAR))))
+    clicked_year <- round(click_x)
+    
+    if (clicked_year >= 1 && clicked_year <= length(year_levels)) {
+      clicked_factor_year <- year_levels[clicked_year]
+      
+      click_point <- balance_data[balance_data$YEAR == clicked_factor_year, ]
+      
+      balance_clicked_point(list(
+        data = click_point,
+        coords_css = input$balance_plot_click$coords_css))
+    } else {
+      balance_clicked_point(NULL)
+    }
+  })
+  
+  # allow user to exit out of tooltip
+  observeEvent(input$close_balance_tooltip, {
+    balance_clicked_point(NULL)
+  })
+  
+  # overlay the clicked point
+  output$balance_click_overlay <- renderUI({
+    click_info <- balance_clicked_point()
+    
+    if (is.null(click_info)) {
+      return(NULL)
+    }
+    
+    left_pos <- click_info$coords_css$x + 10 # offset to right of point
+    top_pos <- click_info$coords_css$y - 10 # offset above point
+    
+    left_pos <- max(10, left_pos)
+    top_pos <- max(10, top_pos)
+    
+    div(
+      style = paste0(
+        "left: ", left_pos, "px;",
+        "top: ", top_pos, "px;",
+        tooltip_aes),
+      # tooltip close button
+      tags$button(
+        "x",
+        id = "close_balance_tooltip",
+        onclick = "Shiny.setInputValue('close_balance_tooltip', Math.random());",
+        style = close_button_aes),
+      HTML(paste0(
+        "<span style = 'font-size: 22px; font-weight: bold; text-decoration: underline;'>", 
+        click_info$data$YEAR[1], ':', "</span><br>",
+        "</span><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>",
+        "Exports:<br></span>", 
+        dollar(click_info$data$value[1]), " Million <br>",
+        "</span><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>",
+        "Imports:<br></span>", 
+        dollar(click_info$data$value[2]), " Million <br>",
+        "</span><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>",
+        "Trade Balance:<br></span>", 
+        dollar(click_info$data$value[3]), " Million <br>"
+      ))
+    )
+  })
+  
+  
+  
+  #' *Volume Ratio Plot*
+  ratio_clicked_point <- reactiveVal(NULL)
+  
+  observeEvent(input$ratio_plot_click, {
+    click_x <- input$ratio_plot_click$x
+    
+    ratio_data <- trade_df()
+    
+    year_levels <- levels(factor(sort(unique(ratio_data$YEAR))))
+    clicked_year <- round(click_x)
+    
+    if (clicked_year >= 1 && clicked_year <= length(year_levels)) {
+      clicked_factor_year <- year_levels[clicked_year]
+      
+      click_point <- ratio_data[ratio_data$YEAR == clicked_factor_year, ]
+      
+      ratio_clicked_point(list(
+        data = click_point,
+        coords_css = input$ratio_plot_click$coords_css))
+    } else {
+      ratio_clicked_point(NULL)
+    }
+  })
+  
+  observeEvent(input$close_ratio_tooltip, {
+    ratio_clicked_point(NULL)
+  })
+  
+  output$ratio_click_overlay <- renderUI({
+    click_info <- ratio_clicked_point()
+    
+    if (is.null(click_info)) {
+      return(NULL)
+    }
+    
+    left_pos <- click_info$coords_css$x + 10
+    top_pos <- click_info$coords_css$y - 10
+    
+    left_pos <- max(10, left_pos)
+    top_pos <- max(10, top_pos)
+    
+    div(
+      style = paste0(
+        "left: ", left_pos, "px;",
+        "top: ", top_pos, "px;",
+        tooltip_aes),
+      tags$button(
+        "x",
+        id = "close_ratio_tooltip",
+        onclick = "Shiny.setInputValue('close_ratio_tooltip', Math.random());",
+        style = close_button_aes),
+      HTML(paste0(
+        "<span style = 'font-size: 22px; font-weight: bold; text-decoration: underline;'>", 
+        click_info$data$YEAR[1], ':', "</span><br>",
+        "</span><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>",
+        "Export Volume:<br></span>", 
+        comma(click_info$data$EXP_VOLUME_MT), " Metric Tons <br>",
+        "</span><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>",
+        "Imports:<br></span>", 
+        comma(click_info$data$IMP_VOLUME_MT), " Metric Tons <br>",
+        "</span><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>",
+        "Ratio:<br></span>", 
+        (click_info$data$EXP_VOLUME_MT / click_info$data$IMP_VOLUME_MT)
+      ))
+    )
+  })
+  
+  
+  
+  #' *Top 5 Trade Plot*
+  top5_clicked_point <- reactiveVal(NULL)
+  
+  observeEvent(input$top5_plot_click, {
+    click_x <- round(input$top5_plot_click$x)
+    
+    top5_data <- top5_trade_df()
+    top5_data <- top5_data %>%
+      mutate(COUNTRY_NAME = gsub(' ', '\n', str_to_title(COUNTRY_NAME)))
+    
+    country_levels <- factor(sort(unique(top5_data$COUNTRY_NAME)))
+    clicked_country <- click_x
+    
+    if (click_x >= 1 && click_x <= 5) {
+      clicked_factor_country <- country_levels[clicked_country]
+      
+      click_point <- top5_data[top5_data$COUNTRY_NAME == clicked_factor_country, ]
+      
+      top5_clicked_point(list(
+        data = click_point,
+        coords_css = input$top5_plot_click$coords_css))
+    } else {
+      top5_clicked_point(NULL)
+    }
+  })
+  
+  observeEvent(input$close_top5_tooltip, {
+    top5_clicked_point(NULL)
+  })
+  
+  output$top5_click_overlay <- renderUI({
+    click_info <- top5_clicked_point()
+    
+    if (is.null(click_info)) {
+      return(NULL)
+    }
+    
+    left_pos <- click_info$coords_css$x + 10
+    top_pos <- click_info$coords_css$y - 10
+    
+    left_pos <- max(10, left_pos)
+    top_pos <- max(10, top_pos)
+    
+    colors <- nmfs_palette('oceans')(5)
+    
+    div(
+      style = paste0(
+        "left: ", left_pos, "px;",
+        "top: ", top_pos, "px;",
+        tooltip_aes),
+      tags$button(
+        "x",
+        id = "close_top5_tooltip",
+        onclick = "Shiny.setInputValue('close_top5_tooltip', Math.random());",
+        style = close_button_aes),
+      HTML(paste0(
+        "<span style = 'font-size: 22px; font-weight: bold; text-decoration: underline;'>", 
+        click_info$data$COUNTRY_NAME[1], ':', "</span><br>",
+        "</span><span class = 'color-swatch' style = 'background-color: ", colors[1], ";'>",
+        "</span><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>",
+        "2020</span>", ': ',
+        dollar(click_info$data$NET_VALUE_2024USD_MILLIONS[1]), " Million <br>",
+        "</span><span class = 'color-swatch' style = 'background-color: ", colors[2], ";'>",
+        "</span><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>",
+        "2021</span>", ': ',
+        dollar(click_info$data$NET_VALUE_2024USD_MILLIONS[2]), " Million <br>",
+        "</span><span class = 'color-swatch' style = 'background-color: ", colors[3], ";'>",
+        "</span><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>",
+        "2022</span>", ': ',
+        dollar(click_info$data$NET_VALUE_2024USD_MILLIONS[3]), " Million <br>",
+        "</span><span class = 'color-swatch' style = 'background-color: ", colors[4], ";'>",
+        "</span><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>",
+        "2023</span>", ': ',
+        dollar(click_info$data$NET_VALUE_2024USD_MILLIONS[4]), " Million <br>",
+        "</span><span class = 'color-swatch' style = 'background-color: ", colors[5], ";'>",
+        "</span><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>",
+        "2024</span>", ': ',
+        dollar(click_info$data$NET_VALUE_2024USD_MILLIONS[5]), " Million <br>")))
+  })
+  
+  
+  
+  #' *Export Value*
+  exp_value_clicked_point <- reactiveVal(NULL)
+  
+  observeEvent(input$exp_value_plot_click, {
+    click_x <- input$exp_value_plot_click$x
+    
+    # store current data
+    trade_data <- trade_df()
+    
+    # require clicked year to be within range
+    year_levels <- levels(factor(trade_data$YEAR))
+    clicked_year <- round(click_x)
+    
+    if (clicked_year >= 1 && clicked_year <= length(year_levels)) {
+      # Get actual factor value
+      clicked_factor_year <- year_levels[clicked_year]
+      
+      # Get data for clicked bar
+      click_point <- trade_data[trade_data$YEAR == clicked_factor_year, ]
+      
+      # store coords of clicked point
+      exp_value_clicked_point(list(
+        data = click_point,
+        coords_css = input$exp_value_plot_click$coords_css))
+    } else {
+      exp_value_clicked_point(NULL)
+    }
+  })
+  
+  observeEvent(input$close_exp_value_tooltip, {
+    exp_value_clicked_point(NULL)
+  })
+  
+  output$exp_value_click_overlay <- renderUI({
+    click_info <- exp_value_clicked_point()
+    
+    if (is.null(click_info)) {
+      return(NULL)
+    }
+    
+    # position tooltip near clicked point
+    left_pos <- click_info$coords_css$x + 10
+    top_pos <- click_info$coords_css$y - 10
+    
+    # keep tooltip within plot bounds
+    
+    left_pos <- max(10, left_pos)
+    top_pos <- max(10, top_pos)
+    
+    # tooltip style
+    div(
+      style = paste0(
+        "left: ", left_pos, "px;",
+        "top: ", top_pos, "px;",
+        tooltip_aes
+      ),
+      
+      # Close button
+      tags$button(
+        "x",
+        id = "close_exp_value_tooltip",
+        onclick = "Shiny.setInputValue('close_exp_value_tooltip', Math.random());",
+        style = close_button_aes
+      ), 
+      
+      # Tooltip info
+      HTML(paste0(
+        "<span style = 'font-size: 22px; font-weight: bold; text-decoration: underline;'>", 
+        click_info$data$YEAR, ":", 
+        "</span><br><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>",
+        "Export Value: ", "</span><span style = 'font-size: 18px;'><br>",
+        dollar(click_info$data$EXP_VALUE_2024USD_MILLIONS), " Million<br>",
+        "</span><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>", 
+        "Export Price: ", "</span><span style = 'font-size: 18px;'><br>",
+        dollar(click_info$data$EXP_PRICE_USD_PER_KG), " per kilogram")))
+  })
+  
+  
+  
+  #' *Import Value*
+  imp_value_clicked_point <- reactiveVal(NULL)
+  
+  observeEvent(input$imp_value_plot_click, {
+    click_x <- input$imp_value_plot_click$x
+    
+    trade_data <- trade_df()
+    
+    year_levels <- levels(factor(trade_data$YEAR))
+    clicked_year <- round(click_x)
+    
+    if (clicked_year >= 1 && clicked_year <= length(year_levels)) {
+      clicked_factor_year <- year_levels[clicked_year]
+      
+      click_point <- trade_data[trade_data$YEAR == clicked_factor_year, ]
+      
+      imp_value_clicked_point(list(
+        data = click_point,
+        coords_css = input$imp_value_plot_click$coords_css))
+    } else {
+      imp_value_clicked_point(NULL)
+    }
+  })
+  
+  observeEvent(input$close_imp_value_tooltip, {
+    imp_value_clicked_point(NULL)
+  })
+  
+  output$imp_value_click_overlay <- renderUI({
+    click_info <- imp_value_clicked_point()
+    
+    if (is.null(click_info)) {
+      return(NULL)
+    }
+    
+    left_pos <- click_info$coords_css$x + 10
+    top_pos <- click_info$coords_css$y - 10
+    
+    left_pos <- max(10, left_pos)
+    top_pos <- max(10, top_pos)
+    
+    div(
+      style = paste0(
+        "left: ", left_pos, "px;",
+        "top: ", top_pos, "px;",
+        tooltip_aes),
+      
+      tags$button(
+        "x",
+        id = "close_imp_value_tooltip",
+        onclick = "Shiny.setInputValue('close_imp_value_tooltip', Math.random());",
+        style = close_button_aes),
+      
+      HTML(paste0(
+        "<span style = 'font-size: 22px; font-weight: bold; text-decoration: underline;'>", 
+        click_info$data$YEAR, ":", 
+        "</span><br><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>",
+        "Import Value: ", "</span><span style = 'font-size: 18px;'><br>",
+        dollar(click_info$data$IMP_VALUE_2024USD_MILLIONS), " Million<br>",
+        "</span><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>", 
+        "Import Price: ", "</span><span style = 'font-size: 18px;'><br>",
+        dollar(click_info$data$IMP_PRICE_USD_PER_KG), " per kilogram")))
+  })
+  
+  
+  
+  #' *Export Volume*
+  exp_volume_clicked_point <- reactiveVal(NULL)
+  
+  observeEvent(input$exp_volume_plot_click, {
+    click_x <- input$exp_volume_plot_click$x
+    
+    # store current data
+    trade_data <- trade_df()
+    
+    # require clicked year to be within range
+    year_levels <- levels(factor(trade_data$YEAR))
+    clicked_year <- round(click_x)
+    
+    if (clicked_year >= 1 && clicked_year <= length(year_levels)) {
+      # Get actual factor value
+      clicked_factor_year <- year_levels[clicked_year]
+      
+      # Get data for clicked bar
+      click_point <- trade_data[trade_data$YEAR == clicked_factor_year, ]
+      
+      # store coords of clicked point
+      exp_volume_clicked_point(list(
+        data = click_point,
+        coords_css = input$exp_volume_plot_click$coords_css))
+    } else {
+      exp_volume_clicked_point(NULL)
+    }
+  })
+  
+  observeEvent(input$close_exp_volume_tooltip, {
+    exp_volume_clicked_point(NULL)
+  })
+  
+  output$exp_volume_click_overlay <- renderUI({
+    click_info <- exp_volume_clicked_point()
+    
+    if (is.null(click_info)) {
+      return(NULL)
+    }
+    
+    # position tooltip near clicked point
+    left_pos <- click_info$coords_css$x + 10
+    top_pos <- click_info$coords_css$y - 10
+    
+    # keep tooltip within plot bounds
+    
+    left_pos <- max(10, left_pos)
+    top_pos <- max(10, top_pos)
+    
+    # tooltip style
+    div(
+      style = paste0(
+        "left: ", left_pos, "px;",
+        "top: ", top_pos, "px;",
+        tooltip_aes
+      ),
+      
+      # Close button
+      tags$button(
+        "x",
+        id = "close_exp_volume_tooltip",
+        onclick = "Shiny.setInputValue('close_exp_volume_tooltip', Math.random());",
+        style = close_button_aes
+      ), 
+      
+      # Tooltip info
+      HTML(paste0(
+        "<span style = 'font-size: 22px; font-weight: bold; text-decoration: underline;'>", 
+        click_info$data$YEAR, ":", 
+        "</span><br><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>",
+        "Export Volume: ", "</span><span style = 'font-size: 18px;'><br>",
+        comma(click_info$data$EXP_VOLUME_MT), " Metric Tons")
+      ))
+  })
+  
+  
+  
+  #' *Import Volume*
+  imp_volume_clicked_point <- reactiveVal(NULL)
+  
+  observeEvent(input$imp_volume_plot_click, {
+    click_x <- input$imp_volume_plot_click$x
+    
+    # store current data
+    trade_data <- trade_df()
+    
+    # require clicked year to be within range
+    year_levels <- levels(factor(trade_data$YEAR))
+    clicked_year <- round(click_x)
+    
+    if (clicked_year >= 1 && clicked_year <= length(year_levels)) {
+      # Get actual factor value
+      clicked_factor_year <- year_levels[clicked_year]
+      
+      # Get data for clicked bar
+      click_point <- trade_data[trade_data$YEAR == clicked_factor_year, ]
+      
+      # store coords of clicked point
+      imp_volume_clicked_point(list(
+        data = click_point,
+        coords_css = input$imp_volume_plot_click$coords_css))
+    } else {
+      imp_volume_clicked_point(NULL)
+    }
+  })
+  
+  observeEvent(input$close_imp_volume_tooltip, {
+    imp_volume_clicked_point(NULL)
+  })
+  
+  output$imp_volume_click_overlay <- renderUI({
+    click_info <- imp_volume_clicked_point()
+    
+    if (is.null(click_info)) {
+      return(NULL)
+    }
+    
+    # position tooltip near clicked point
+    left_pos <- click_info$coords_css$x + 10
+    top_pos <- click_info$coords_css$y - 10
+    
+    # keep tooltip within plot bounds
+    
+    left_pos <- max(10, left_pos)
+    top_pos <- max(10, top_pos)
+    
+    # tooltip style
+    div(
+      style = paste0(
+        "left: ", left_pos, "px;",
+        "top: ", top_pos, "px;",
+        tooltip_aes
+      ),
+      
+      # Close button
+      tags$button(
+        "x",
+        id = "close_imp_volume_tooltip",
+        onclick = "Shiny.setInputValue('close_imp_volume_tooltip', Math.random());",
+        style = close_button_aes
+      ), 
+      
+      # Tooltip info
+      HTML(paste0(
+        "<span style = 'font-size: 22px; font-weight: bold; text-decoration: underline;'>", 
+        click_info$data$YEAR, ":", 
+        "</span><br><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>",
+        "Import Volume: ", "</span><span style = 'font-size: 18px;'><br>",
+        comma(click_info$data$IMP_VOLUME_MT), " Metric Tons")))
+  })
+  
+  
+  
+  #' *MLTI Exports*
+  # Stores data point information and pixel coordinates where user clicked
+  exp_mlti_clicked_point <- reactiveVal(NULL)
+  
+  # Handle click events and store clicked point
+  observeEvent(input$exp_mlti_plot_click, {
+
+    click_x <- input$exp_mlti_plot_click$x
+    
+    mlti_data <- exp_mlti_table_df()
+    
+    year_levels <- levels(factor(sort(unique(mlti_data$YEAR))))
+    clicked_year <- round(click_x)
+    
+    # require clicked year to be within range
+    if (clicked_year >= 1 && clicked_year <= length(year_levels)) {
+      clicked_factor_year <- year_levels[clicked_year]
+      
+      click_point <- mlti_data[mlti_data$YEAR == clicked_factor_year, ]
+      
+      exp_mlti_clicked_point(list(
+        data = click_point,
+        coords_css = input$exp_mlti_plot_click$coords_css))
+    } else {
+      exp_mlti_clicked_point(NULL)
+    }
+  })
+  
+  # allow user to exit out of tooltip
+  observeEvent(input$close_exp_mlti_tooltip, {
+    exp_mlti_clicked_point(NULL)
+  })
+  
+  # overlay the clicked point
+  output$exp_mlti_click_overlay <- renderUI({
+    click_info <- exp_mlti_clicked_point()
+    
+    if (is.null(click_info)) {
+      return(NULL)
+    }
+    
+    # SPECIFY POINT SHAPES
+    # First, get data
+    mlti_data <- exp_mlti_table_df()
+    # Next, get countries
+    countries <- unique(mlti_data$COUNTRY_NAME)
+    # Assign the shapes to these countries
+      # the countries are already sorted alphabetically in data
+    point_shapes <- c(16, 17, 15, 3, 7)
+    names(point_shapes) <- c(countries)
+    # set names for mlti_colors
+    new_mlti_colors <- mlti_colors
+    names(new_mlti_colors) <- c(countries)
+    # create all 5 icons
+    icon_1 <- create_tooltip_icon(new_mlti_colors[1], point_shapes[1])
+    icon_2 <- create_tooltip_icon(new_mlti_colors[2], point_shapes[2])
+    icon_3 <- create_tooltip_icon(new_mlti_colors[3], point_shapes[3])
+    icon_4 <- create_tooltip_icon(new_mlti_colors[4], point_shapes[4])
+    icon_5 <- create_tooltip_icon(new_mlti_colors[5], point_shapes[5])
+    
+    # Position tooltip near clicked point
+    left_pos <- click_info$coords_css$x + 10 # Offset to right of point
+    top_pos <- click_info$coords_css$y - 10 # Offset above point
+    
+    # Prevent tooltip from being off screen
+    left_pos <- max(10, left_pos)
+    top_pos <- max(10, top_pos)
+    
+    # style the tooltip for clicked point
+    div(
+      style = paste0(
+        "left: ", left_pos, "px;",
+        "top: ", top_pos, "px;",
+        tooltip_aes),
+      # tooltip close button
+      tags$button(
+        "x",
+        id = 'close_exp_mlti_tooltip',
+        onclick = "Shiny.setInputValue('close_exp_mlti_tooltip', Math.random());",
+        style = close_button_aes), 
+      HTML(paste0(
+        "<span style = 'font-size: 18px; font-weight: bold; text-decoration: underline;'>", 
+        click_info$data$YEAR[1], ':', "</span><br>",
+        '<img src = "', icon_1, '" class = "tooltip-icon" alt = "legend icon"/>',
+        "<strong>", str_to_title(click_info$data$COUNTRY_NAME[1]), "</strong><br/>",
+        "MLTI: ", round(click_info$data$MLTI[1], digits = 3), "<br>",
+        '<img src = "', icon_2, '" class = "tooltip-icon" alt = "legend icon"/>',
+        "<strong>", str_to_title(click_info$data$COUNTRY_NAME[2]), "</strong><br/>",
+        "MLTI: ", round(click_info$data$MLTI[2], digits = 3), "<br>",
+        '<img src = "', icon_3, '" class = "tooltip-icon" alt = "legend icon"/>',
+        "<strong>", str_to_title(click_info$data$COUNTRY_NAME[3]), "</strong><br/>",
+        "MLTI: ", round(click_info$data$MLTI[3], digits = 3), "<br>",
+        '<img src = "', icon_4, '" class = "tooltip-icon" alt = "legend icon"/>',
+        "<strong>", str_to_title(click_info$data$COUNTRY_NAME[4]), "</strong><br/>",
+        "MLTI: ", round(click_info$data$MLTI[4], digits = 3), "<br>",
+        '<img src = "', icon_5, '" class = "tooltip-icon" alt = "legend icon"/>',
+        "<strong>", str_to_title(click_info$data$COUNTRY_NAME[5]), "</strong><br/>",
+        "MLTI: ", round(click_info$data$MLTI[5], digits = 3), "<br>"
+      ))
+    )
+  })
+  
+  
+  
+  #' *MLTI Imports*
+  imp_mlti_clicked_point <- reactiveVal(NULL)
+  
+  observeEvent(input$imp_mlti_plot_click, {
+    
+    click_x <- input$imp_mlti_plot_click$x
+    
+    mlti_data <- imp_mlti_table_df()
+    
+    year_levels <- levels(factor(sort(unique(mlti_data$YEAR))))
+    clicked_year <- round(click_x)
+    
+    if (clicked_year >= 1 && clicked_year <= length(year_levels)) {
+      clicked_factor_year <- year_levels[clicked_year]
+      
+      click_point <- mlti_data[mlti_data$YEAR == clicked_factor_year, ]
+      
+      imp_mlti_clicked_point(list(
+        data = click_point,
+        coords_css = input$imp_mlti_plot_click$coords_css))
+    } else {
+      imp_mlti_clicked_point(NULL)
+    }
+  })
+  
+  observeEvent(input$close_imp_mlti_tooltip, {
+    imp_mlti_clicked_point(NULL)
+  })
+  
+  output$imp_mlti_click_overlay <- renderUI({
+    click_info <- imp_mlti_clicked_point()
+    
+    if(is.null(click_info)) {
+      return(NULL)
+    }
+    
+    # SPECIFY POINT SHAPES
+    mlti_data <- imp_mlti_table_df()
+    
+    countries <- unique(mlti_data$COUNTRY_NAME)
+    
+    point_shapes <- c(16, 17, 15, 3, 7)
+    names(point_shapes) <- c(countries)
+    
+    new_mlti_colors <- mlti_colors
+    names(new_mlti_colors) <- c(countries)
+    
+    icon_1 <- create_tooltip_icon(new_mlti_colors[1], point_shapes[1])
+    icon_2 <- create_tooltip_icon(new_mlti_colors[2], point_shapes[2])
+    icon_3 <- create_tooltip_icon(new_mlti_colors[3], point_shapes[3])
+    icon_4 <- create_tooltip_icon(new_mlti_colors[4], point_shapes[4])
+    icon_5 <- create_tooltip_icon(new_mlti_colors[5], point_shapes[5])
+    
+    
+    left_pos <- click_info$coords_css$x + 10 # Offset to right of point
+    top_pos <- click_info$coords_css$y - 10 # Offset above point
+
+    left_pos <- max(10, left_pos)
+    top_pos <- max(10, top_pos)
+    
+    
+    div(
+      style = paste0(
+        "left: ", left_pos, "px;",
+        "top: ", top_pos, "px;",
+        tooltip_aes),
+      # tooltip close button
+      tags$button(
+        "x",
+        id = 'close_imp_mlti_tooltip',
+        onclick = "Shiny.setInputValue('close_imp_mlti_tooltip', Math.random());",
+        style = close_button_aes
+      ), 
+      HTML(paste0(
+        "<span style = 'font-size: 18px; font-weight: bold; text-decoration: underline;'>", 
+        click_info$data$YEAR[1], ':', "</span><br>",
+        '<img src = "', icon_1, '" class = "tooltip-icon" alt = "legend icon"/>',
+        "<strong>", str_to_title(click_info$data$COUNTRY_NAME[1]), "</strong><br/>",
+        "MLTI: ", round(click_info$data$MLTI[1], digits = 3), "<br>",
+        '<img src = "', icon_2, '" class = "tooltip-icon" alt = "legend icon"/>',
+        "<strong>", str_to_title(click_info$data$COUNTRY_NAME[2]), "</strong><br/>",
+        "MLTI: ", round(click_info$data$MLTI[2], digits = 3), "<br>",
+        '<img src = "', icon_3, '" class = "tooltip-icon" alt = "legend icon"/>',
+        "<strong>", str_to_title(click_info$data$COUNTRY_NAME[3]), "</strong><br/>",
+        "MLTI: ", round(click_info$data$MLTI[3], digits = 3), "<br>",
+        '<img src = "', icon_4, '" class = "tooltip-icon" alt = "legend icon"/>',
+        "<strong>", str_to_title(click_info$data$COUNTRY_NAME[4]), "</strong><br/>",
+        "MLTI: ", round(click_info$data$MLTI[4], digits = 3), "<br>",
+        '<img src = "', icon_5, '" class = "tooltip-icon" alt = "legend icon"/>',
+        "<strong>", str_to_title(click_info$data$COUNTRY_NAME[5]), "</strong><br/>",
+        "MLTI: ", round(click_info$data$MLTI[5], digits = 3), "<br>"
+      ))
+    )
+  })
+  
+  
+  
+  #' *Herfindahl Index*
+  hi_clicked_point <- reactiveVal(NULL)
+  
+  observeEvent(input$hi_plot_click, {
+    click_x <- input$hi_plot_click$x
+    
+    hi_data <- calculate_hi(species_selection_trade(), nominal = selected_value())
+    
+    year_levels <- levels(factor(sort(unique(hi_data$YEAR))))
+    clicked_year <- round(click_x)
+    
+    if (clicked_year >= 1 && clicked_year <= length(year_levels)) {
+      clicked_factor_year <- year_levels[clicked_year]
+      
+      click_point <- hi_data[hi_data$YEAR == clicked_factor_year, ]
+      
+      hi_clicked_point(list(
+        data = click_point,
+        coords_css = input$hi_plot_click$coords_css))
+    } else {
+      hi_clicked_point(NULL)
+    }
+  })
+  
+  observeEvent(input$close_hi_tooltip, {
+    hi_clicked_point(NULL)
+  })
+  
+  output$hi_click_overlay <- renderUI({
+    click_info <- hi_clicked_point()
+    
+    if (is.null(click_info)) {
+      return(NULL)
+    }
+    
+    # create legend icons
+    exp_icon <- create_tooltip_icon('#003087', 16)
+    imp_icon <- create_tooltip_icon('#0085CA', 16)
+    
+    left_pos <- click_info$coords_css$x + 10 # Offset to right of point
+    top_pos <- click_info$coords_css$y - 10 # Offset above point
+    
+    left_pos <- max(10, left_pos)
+    top_pos <- max(10, top_pos)
+    
+    div(
+      style = paste0(
+        "left: ", left_pos, "px;",
+        "top: ", top_pos, "px;",
+        tooltip_aes),
+      tags$button(
+        "x",
+        id = 'close_hi_tooltip',
+        onclick = "Shiny.setInputValue('close_hi_tooltip', Math.random());",
+        style = close_button_aes), 
+      HTML(paste0(
+        "<span style = 'font-size: 18px; font-weight: bold; text-decoration: underline;'>", 
+        click_info$data$YEAR[1], ':', "</span><br>",
+        '<img src = "', exp_icon, '" class = "tooltip-icon" alt = "legend icon"/>',
+        "Export: ", round(click_info$data$EXP_HI, digits = 3), "<br>",
+        '<img src = "', imp_icon, '" class = "tooltip-icon" alt = "legend icon"/>',
+        "Import: ", round(click_info$data$IMP_HI, digits = 3)
+      ))
+    )
+  })
+  
+  
+  
+  #' *Apparent Supply*
+  supply_clicked_point <- reactiveVal(NULL)
+  
+  observe({
+    if (!is.null(input$supply_plot_click)) {
+      # Get clicked coordinates (bc it's a bar chart, different from exp_mlti)
+      click_x <- input$supply_plot_click$x
+      click_y <- input$supply_plot_click$y
+    
+      # Store current data
+      supply_data <- supply_df()
+      
+      # Factored x-axis for years requires extra wrangling
+      year_levels <- levels(factor(supply_data$YEAR))
+      clicked_year <- round(click_x)
+      
+      # require clicked year to be within range
+      if (clicked_year >= 1 && clicked_year <= length(year_levels)) {
+        # Get actual factor value
+        clicked_factor_year <- year_levels[clicked_year]
+        
+        # Get data for clicked bar
+        click_point <- supply_data[supply_data$YEAR == clicked_factor_year, ]
+        
+        # tooltip only shows when bar is clicked (y < supply)
+        if (click_y >= 0 && click_y <= click_point$APPARENT_SUPPLY) {
+          # store coords of clicked point
+          supply_clicked_point(list(
+            data = click_point,
+            coords_css = input$supply_plot_click$coords_css
+          ))
+        } else {
+          supply_clicked_point(NULL)
+        }
+      } else {
+        supply_clicked_point(NULL)
+      }
+    }
+  })
+  
+  observeEvent(input$close_supply_tooltip, {
+    supply_clicked_point(NULL)
+  })
+  
+  output$supply_click_overlay <- renderUI({
+    click_info <- supply_clicked_point()
+    
+    if (is.null(click_info)) {
+      return(NULL)
+    }
+    
+    # position tooltip near clicked point
+    left_pos <- click_info$coords_css$x + 10
+    top_pos <- click_info$coords_css$y - 10
+    
+    # keep tooltip within plot bounds
+    left_pos <- max(10, left_pos)
+    top_pos <- max(10, top_pos)
+    
+    # tooltip style
+    div(
+      style = paste0(
+        "left: ", left_pos, "px;",
+        "top: ", top_pos, "px;",
+        tooltip_aes),
+      
+      # Close button
+      tags$button(
+        "x",
+        id = "close_supply_tooltip",
+        onclick = "Shiny.setInputValue('close_supply_tooltip', Math.random());",
+        style = close_button_aes), 
+      
+      # Tooltip info
+      HTML(paste0(
+        "<strong>", click_info$data$YEAR, ":", "</strong><br/>",
+        comma((click_info$data$APPARENT_SUPPLY / 1000)),
+        " Thousand ", ifelse(input$units == F, "Metric Tons", "Short Tons")
+      ))
+    )
+  })
+  
+  
+  
+  #' *Supply Ratio*
+  supply_ratio_clicked_point <- reactiveVal(NULL)
+  
+  observeEvent(input$supply_ratio_plot_click, {
+    click_x <- input$supply_ratio_plot_click$x
+    
+    supply_data <- supply_df()
+    
+    year_levels <- levels(factor(sort(unique(supply_data$YEAR))))
+    clicked_year <- round(click_x)
+    
+    if (clicked_year >= 1 && clicked_year <= length(year_levels)) {
+      clicked_factor_year <- year_levels[clicked_year]
+      
+      click_point <- supply_data[supply_data$YEAR == clicked_factor_year, ]
+      
+      supply_ratio_clicked_point(list(
+        data = click_point,
+        coords_css = input$supply_ratio_plot_click$coords_css))
+    } else {
+      supply_ratio_clicked_point(NULL)
+    }
+  })
+  
+  observeEvent(input$close_supply_ratio_tooltip, {
+    supply_ratio_clicked_point(NULL)
+  })
+  
+  output$supply_ratio_click_overlay <- renderUI({
+    click_info <- supply_ratio_clicked_point()
+    
+    if (is.null(click_info)) {
+      return(NULL)
+    }
+    
+    left_pos <- click_info$coords_css$x + 10
+    top_pos <- click_info$coords_css$y - 10
+    
+    left_pos <- max(10, left_pos)
+    top_pos <- max(10, top_pos)
+    
+    div(
+      style = paste0(
+        "left: ", left_pos, "px;",
+        "top: ", top_pos, "px;",
+        tooltip_aes),
+      tags$button(
+        "x",
+        id = 'close_supply_ratio_tooltip',
+        onclick = "Shiny.setInputValue('close_supply_ratio_tooltip', Math.random());",
+        style = close_button_aes),
+      HTML(paste0(
+        "<span style = 'font-size: 18px; font-weight: bold; text-decoration: underline;'>", 
+        click_info$data$YEAR[1], ':', "</span><br>",
+        "</span><span style = 'font-size: 16px; font-style: italic; text-decoration: underline;'>",
+        "Apparent Supply", "</span>",  ":<br>",
+        comma(click_info$data$APPARENT_SUPPLY), " Metric Tons <br>",
+        "</span><span style = 'font-size: 16px; font-style: italic; text-decoration: underline;'>",
+        "Domestic Production Volume", "</span>", ":<br>",
+        comma(click_info$data$PP_VOLUME_MT), " Metric Tons <br>",
+        "</span><span style = 'font-size: 16px; font-style: italic; text-decoration: underline;'>",
+        "Ratio", "</span>", ":<br>",
+        round(click_info$data$APPARENT_SUPPLY_REL_US_PROD, digits = 3))))
+  })
+  
+  
+  
+  #' *Supply Share*
+  supply_share_clicked_point <- reactiveVal(NULL)
+  
+  observeEvent(input$supply_share_plot_click, {
+    click_x <- input$supply_share_plot_click$x
+    
+    supply_data <- supply_df()
+    
+    year_levels <- levels(factor(sort(unique(supply_data$YEAR))))
+    clicked_year <- round(click_x)
+    
+    if (clicked_year >= 1 && clicked_year <= length(year_levels)) {
+      clicked_factor_year <- year_levels[clicked_year]
+      
+      click_point <- supply_data[supply_data$YEAR == clicked_factor_year, ]
+      
+      supply_share_clicked_point(list(
+        data = click_point,
+        coords_css = input$supply_share_plot_click$coords_css))
+    } else {
+      supply_share_clicked_point(NULL)
+    }
+  })
+  
+  observeEvent(input$close_supply_share_tooltip, {
+    supply_share_clicked_point(NULL)
+  })
+  
+  output$supply_share_click_overlay <- renderUI({
+    click_info <- supply_share_clicked_point()
+    
+    if (is.null(click_info)) {
+      return(NULL)
+    }
+    
+    left_pos <- click_info$coords_css$x + 10
+    top_pos <- click_info$coords_css$y - 10
+    
+    left_pos <- max(10, left_pos)
+    top_pos <- max(10, top_pos)
+    
+    div(
+      style = paste0(
+        "left: ", left_pos, "px;",
+        "top: ", top_pos, "px;",
+        tooltip_aes),
+      tags$button(
+        "x",
+        id = 'close_supply_share_tooltip',
+        onclick = "Shiny.setInputValue('close_supply_share_tooltip', Math.random());",
+        style = close_button_aes),
+      HTML(paste0(
+        "<span style = 'font-size: 18px; font-weight: bold; text-decoration: underline;'>", 
+        click_info$data$YEAR[1], ':', "</span><br>",
+        "</span><span style = 'font-size: 16px; font-style: italic; text-decoration: underline;'>",
+        "Unexported Domestic Production", "</span>",  ":<br>",
+        comma(abs(click_info$data$PP_VOLUME_MT - click_info$data$EXP_VOLUME_MT)), " Metric Tons <br>",
+        "</span><span style = 'font-size: 16px; font-style: italic; text-decoration: underline;'>",
+        "Apparent Supply", "</span>", ":<br>",
+        comma(click_info$data$APPARENT_SUPPLY), " Metric Tons <br>",
+        "</span><span style = 'font-size: 16px; font-style: italic; text-decoration: underline;'>",
+        "Share", "</span>", ":<br>",
+        round(click_info$data$UNEXPORTED_US_PROD_REL_APPARENT_SUPPLY * 100, digits = 3), "% of Apparent Supply")))
+  })
+  
+  
+  
+  #' *Landings Value*
+  landings_value_clicked_point <- reactiveVal(NULL)
+  
+  observeEvent(input$landings_value_plot_click, {
+    click_x <- input$landings_value_plot_click$x
+    
+    landings_data <- landings_df()
+    
+    year_levels <- levels(factor(sort(unique(landings_data$YEAR))))
+    clicked_year <- round(click_x)
+    
+    if (clicked_year >= 1 && clicked_year <= length(year_levels)) {
+      clicked_factor_year <- year_levels[clicked_year]
+      
+      click_point <- landings_data[landings_data$YEAR == clicked_factor_year, ]
+      
+      landings_value_clicked_point(list(
+        data = click_point,
+        coords_css = input$landings_value_plot_click$coords_css))
+    } else {
+      landings_value_clicked_point(NULL)
+    }
+  })
+  
+  observeEvent(input$close_landings_value_tooltip, {
+    landings_value_clicked_point(NULL)
+  })
+  
+  output$landings_value_click_overlay <- renderUI({
+    click_info <- landings_value_clicked_point()
+    
+    if (is.null(click_info)) {
+      return(NULL)
+    }
+    
+    left_pos <- click_info$coords_css$x + 10
+    top_pos <- click_info$coords_css$y - 10
+    
+    left_pos <- max(10, left_pos)
+    top_pos <- max(10, top_pos)
+    
+    div(
+      style = paste0(
+        "left: ", left_pos, "px;",
+        "top: ", top_pos, "px;",
+        tooltip_aes),
+      tags$button(
+        "x",
+        id = 'close_landings_value_tooltip',
+        onclick = "Shiny.setInputValue('close_landings_value_tooltip', Math.random());",
+        style = close_button_aes),
+      HTML(paste0(
+        "<span style = 'font-size: 22px; font-weight: bold; text-decoration: underline;'>", 
+        click_info$data$YEAR, ":", 
+        "</span><br><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>",
+        "Ex-Vessel Value: ", "</span><span style = 'font-size: 18px;'><br>",
+        dollar(click_info$data$COM_VALUE_MILLIONS_2024USD), " Million<br>",
+        "</span><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>", 
+        "Ex-Vessel Price: ", "</span><span style = 'font-size: 18px;'><br>",
+        dollar(click_info$data$COM_PRICE_2024USD_PER_KG), " per kilogram")))
+  })
+  
+  
+  
+  #' *Landings Volume*
+  landings_volume_clicked_point <- reactiveVal(NULL)
+  
+  observeEvent(input$landings_volume_plot_click, {
+    click_x <- input$landings_volume_plot_click$x
+    
+    landings_data <- landings_df()
+    
+    year_levels <- levels(factor(sort(unique(landings_data$YEAR))))
+    clicked_year <- round(click_x)
+    
+    if (clicked_year >= 1 && clicked_year <= length(year_levels)) {
+      clicked_factor_year <- year_levels[clicked_year]
+      
+      click_point <- landings_data[landings_data$YEAR == clicked_factor_year, ]
+      
+      landings_volume_clicked_point(list(
+        data = click_point,
+        coords_css = input$landings_volume_plot_click$coords_css))
+    } else {
+      landings_volume_clicked_point(NULL)
+    }
+  })
+  
+  observeEvent(input$close_landings_value_tooltip, {
+    landings_volume_clicked_point(NULL)
+  })
+  
+  output$landings_volume_click_overlay <- renderUI({
+    click_info <- landings_volume_clicked_point()
+    
+    if (is.null(click_info)) {
+      return(NULL)
+    }
+    
+    left_pos <- click_info$coords_css$x + 10
+    top_pos <- click_info$coords_css$y - 10
+    
+    left_pos <- max(10, left_pos)
+    top_pos <- max(10, top_pos)
+    
+    div(
+      style = paste0(
+        "left: ", left_pos, "px;",
+        "top: ", top_pos, "px;",
+        tooltip_aes),
+      tags$button(
+        "x",
+        id = 'close_landings_volume_tooltip',
+        onclick = "Shiny.setInputValue('close_landings_volume_tooltip', Math.random());",
+        style = close_button_aes),
+      HTML(paste0(
+        "<span style = 'font-size: 22px; font-weight: bold; text-decoration: underline;'>", 
+        click_info$data$YEAR, ":", 
+        "</span><br><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>",
+        "Landed Volume: ", "</span><span style = 'font-size: 18px;'><br>",
+        comma(click_info$data$COM_VOLUME_MT), " Metric Tons")))
+  })
+  
+  
+  
+  #' *Processed Product Value*
+  pp_value_clicked_point <- reactiveVal(NULL)
+  
+  observeEvent(input$pp_value_plot_click, {
+    click_x <- input$pp_value_plot_click$x
+    
+    pp_data <- pp_df()
+    
+    year_levels <- levels(factor(sort(unique(pp_data$YEAR))))
+    clicked_year <- round(click_x)
+    
+    if (clicked_year >= 1 && clicked_year <= length(year_levels)) {
+      clicked_factor_year <- year_levels[clicked_year]
+      
+      click_point <- pp_data[pp_data$YEAR == clicked_factor_year, ]
+      
+      pp_value_clicked_point(list(
+        data = click_point,
+        coords_css = input$pp_value_plot_click$coords_css))
+    } else {
+      pp_value_clicked_point(NULL)
+    }
+  })
+  
+  observeEvent(input$close_pp_value_tooltip, {
+    pp_value_clicked_point(NULL)
+  })
+  
+  output$pp_value_click_overlay <- renderUI({
+    click_info <- pp_value_clicked_point()
+    
+    if (is.null(click_info)) {
+      return(NULL)
+    }
+    
+    # SPECIFY GROUPS
+    # First, get data
+    pp_data <- pp_df()
+    
+    # get the low proportions embedded in pp plot function
+    low_prop_types_value <- pp_data %>% 
+      select(PP_VALUE_BILLIONS_2024USD, PRODUCT_NAME) %>%
+      group_by(PRODUCT_NAME) %>%
+      summarise(across(where(is.numeric), sum),
+                .groups = 'drop') %>%
+      mutate(TOTAL_VALUE = sum(PP_VALUE_BILLIONS_2024USD),
+             VALUE_SHARE = PP_VALUE_BILLIONS_2024USD / TOTAL_VALUE) %>%
+      filter(VALUE_SHARE < 0.02) %>%
+      select(PRODUCT_NAME)
+    
+    low_prop_types_volume <- pp_data %>%
+      select(PP_VOLUME_MT, PRODUCT_NAME) %>%
+      group_by(PRODUCT_NAME) %>%
+      summarise(across(where(is.numeric), sum),
+                .groups = 'drop') %>%
+      mutate(TOTAL_VOLUME = sum(PP_VOLUME_MT),
+             VOLUME_SHARE = PP_VOLUME_MT / TOTAL_VOLUME) %>%
+      filter(VOLUME_SHARE < 0.02) %>%
+      select(PRODUCT_NAME)
+    
+    low_prop_types <- bind_rows(low_prop_types_value, low_prop_types_volume) %>%
+      distinct() %>%
+      pull(PRODUCT_NAME)
+    
+    # rename these low proportion types as 'OTHER*' and re-summarise
+    new_data <- pp_data %>%
+      mutate(PRODUCT_NAME = ifelse(PRODUCT_NAME %in% c('OTHER', low_prop_types),
+                                   'OTHER*', PRODUCT_NAME)) %>%
+      group_by(YEAR, PRODUCT_NAME) %>%
+      summarise(across(where(is.numeric), sum),
+                .groups = 'drop') %>%
+      mutate(PP_PRICE_2024USD_PER_KG = PP_VALUE_2024USD / PP_VOLUME_KG,
+             PP_PRICE_2024USD_PER_LB = PP_VALUE_2024USD / PP_VOLUME_LB,
+             PP_VOLUME_THOUSAND_MT = PP_VOLUME_MT / 1000,
+             PP_VOLUME_THOUSAND_ST = PP_VOLUME_ST / 1000,
+             PP_NOMINAL_PRICE_2024USD_PER_KG = PP_NOMINAL_VALUE / PP_VOLUME_KG,
+             PP_NOMINAL_PRICE_2024USD_PER_LB = PP_NOMINAL_VALUE / PP_VOLUME_LB)
+    
+    # Next, get product forms
+    products <- unique(str_to_title(new_data$PRODUCT_NAME))
+    # Subset colors for these products
+    pp_colors <- colors[names(colors) %in% products]
+    pp_colors <- pp_colors[order(names(pp_colors))]
+    
+    filtered_new_data <- new_data %>% 
+      filter(YEAR == click_info$data$YEAR[1]) %>%
+      arrange(PRODUCT_NAME)
+    
+    # create icons (number will vary)
+    # begin with empty vector that will ultimately contain the full HTML code
+    pp_val_tooltip <- vector()
+    for (i in 1:length(pp_colors)) {
+      tooltip_color <- paste0(
+        "</span><span class = 'color-swatch' style = 'background-color: ", 
+        pp_colors[i], ";'>")
+      
+      tooltip_text <- paste0(
+        "</span><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>",
+        names(pp_colors)[i], "</span>: ")
+      
+      tooltip_data <- paste0(
+        dollar(filtered_new_data$PP_VALUE_MILLIONS_2024USD[i]), " Million <br>"
+      )
+      
+      pp_val_tooltip <- paste0(pp_val_tooltip, 
+                               tooltip_color, tooltip_text, tooltip_data)
+    }
+  
+    # Position tooltip near clicked point
+    left_pos <- click_info$coords_css$x + 20 # Offset to right of point
+    top_pos <- click_info$coords_css$y - 20 # Offset above point
+    
+    # Prevent tooltip from being off screen
+    left_pos <- max(10, left_pos)
+    top_pos <- max(10, top_pos)
+    
+    # style the tooltip for clicked point
+    div(
+      style = paste0(
+        "left: ", left_pos, "px;",
+        "top: ", top_pos, "px;",
+        tooltip_aes,
+        "max-width: 350px; ",
+        "min-width: 350px; "),
+      # tooltip close button
+      tags$button(
+        "x",
+        id = 'close_pp_value_tooltip',
+        onclick = "Shiny.setInputValue('close_pp_value_tooltip', Math.random());",
+        style = close_button_aes), 
+      HTML(paste0(
+        "<span style = 'font-size: 22px; font-weight: bold; text-decoration: underline;'>", 
+        click_info$data$YEAR[1], ':', "</span><br>",
+        pp_val_tooltip)))
+  })
+  
+  
+  
+  #' *Processed Product Volume*
+  pp_volume_clicked_point <- reactiveVal(NULL)
+  
+  observeEvent(input$pp_volume_plot_click, {
+    click_x <- input$pp_volume_plot_click$x
+    
+    pp_data <- pp_df()
+    
+    year_levels <- levels(factor(sort(unique(pp_data$YEAR))))
+    clicked_year <- round(click_x)
+    
+    if (clicked_year >= 1 && clicked_year <= length(year_levels)) {
+      clicked_factor_year <- year_levels[clicked_year]
+      
+      click_point <- pp_data[pp_data$YEAR == clicked_factor_year, ]
+      
+      pp_volume_clicked_point(list(
+        data = click_point,
+        coords_css = input$pp_volume_plot_click$coords_css))
+    } else {
+      pp_volume_clicked_point(NULL)
+    }
+  })
+  
+  observeEvent(input$close_pp_volume_tooltip, {
+    pp_volume_clicked_point(NULL)
+  })
+  
+  output$pp_volume_click_overlay <- renderUI({
+    click_info <- pp_volume_clicked_point()
+    
+    if (is.null(click_info)) {
+      return(NULL)
+    }
+    
+    # SPECIFY GROUPS
+    # First, get data
+    pp_data <- pp_df()
+    
+    # get the low proportions embedded in pp plot function
+    low_prop_types_value <- pp_data %>% 
+      select(PP_VALUE_BILLIONS_2024USD, PRODUCT_NAME) %>%
+      group_by(PRODUCT_NAME) %>%
+      summarise(across(where(is.numeric), sum),
+                .groups = 'drop') %>%
+      mutate(TOTAL_VALUE = sum(PP_VALUE_BILLIONS_2024USD),
+             VALUE_SHARE = PP_VALUE_BILLIONS_2024USD / TOTAL_VALUE) %>%
+      filter(VALUE_SHARE < 0.02) %>%
+      select(PRODUCT_NAME)
+    
+    low_prop_types_volume <- pp_data %>%
+      select(PP_VOLUME_MT, PRODUCT_NAME) %>%
+      group_by(PRODUCT_NAME) %>%
+      summarise(across(where(is.numeric), sum),
+                .groups = 'drop') %>%
+      mutate(TOTAL_VOLUME = sum(PP_VOLUME_MT),
+             VOLUME_SHARE = PP_VOLUME_MT / TOTAL_VOLUME) %>%
+      filter(VOLUME_SHARE < 0.02) %>%
+      select(PRODUCT_NAME)
+    
+    low_prop_types <- bind_rows(low_prop_types_value, low_prop_types_volume) %>%
+      distinct() %>%
+      pull(PRODUCT_NAME)
+    
+    # rename these low proportion types as 'OTHER*' and re-summarise
+    new_data <- pp_data %>%
+      mutate(PRODUCT_NAME = ifelse(PRODUCT_NAME %in% c('OTHER', low_prop_types),
+                                   'OTHER*', PRODUCT_NAME)) %>%
+      group_by(YEAR, PRODUCT_NAME) %>%
+      summarise(across(where(is.numeric), sum),
+                .groups = 'drop') %>%
+      mutate(PP_PRICE_2024USD_PER_KG = PP_VALUE_2024USD / PP_VOLUME_KG,
+             PP_PRICE_2024USD_PER_LB = PP_VALUE_2024USD / PP_VOLUME_LB,
+             PP_VOLUME_THOUSAND_MT = PP_VOLUME_MT / 1000,
+             PP_VOLUME_THOUSAND_ST = PP_VOLUME_ST / 1000,
+             PP_NOMINAL_PRICE_2024USD_PER_KG = PP_NOMINAL_VALUE / PP_VOLUME_KG,
+             PP_NOMINAL_PRICE_2024USD_PER_LB = PP_NOMINAL_VALUE / PP_VOLUME_LB)
+    
+    # Next, get product forms
+    products <- unique(str_to_title(new_data$PRODUCT_NAME))
+    # Subset colors for these products
+    pp_colors <- colors[names(colors) %in% products]
+    pp_colors <- pp_colors[order(names(pp_colors))]
+    
+    filtered_new_data <- new_data %>% 
+      filter(YEAR == click_info$data$YEAR[1]) %>%
+      arrange(PRODUCT_NAME)
+    
+    # create icons (number will vary)
+    # begin with empty vector that will ultimately contain the full HTML code
+    pp_vol_tooltip <- vector()
+    for (i in 1:length(pp_colors)) {
+      tooltip_color <- paste0(
+        "</span><span class = 'color-swatch' style = 'background-color: ", 
+        pp_colors[i], ";'>")
+      
+      tooltip_text <- paste0(
+        "</span><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>",
+        names(pp_colors)[i], "</span>: ")
+      
+      tooltip_data <- paste0(
+        comma(filtered_new_data$PP_VOLUME_THOUSAND_MT[i]), " Thousand Metric Tons <br>"
+      )
+      
+      pp_vol_tooltip <- paste0(pp_vol_tooltip, 
+                               tooltip_color, tooltip_text, tooltip_data)
+    }
+    
+    # Position tooltip near clicked point
+    left_pos <- click_info$coords_css$x + 20 # Offset to right of point
+    top_pos <- click_info$coords_css$y - 20 # Offset above point
+    
+    # Prevent tooltip from being off screen
+    left_pos <- max(10, left_pos)
+    top_pos <- max(10, top_pos)
+    
+    # style the tooltip for clicked point
+    div(
+      style = paste0(
+        "left: ", left_pos, "px;",
+        "top: ", top_pos, "px;",
+        tooltip_aes,
+        "max-width: 350px; ",
+        "min-width: 350px; "),
+      # tooltip close button
+      tags$button(
+        "x",
+        id = 'close_pp_volume_tooltip',
+        onclick = "Shiny.setInputValue('close_pp_volume_tooltip', Math.random());",
+        style = close_button_aes), 
+      HTML(paste0(
+        "<span style = 'font-size: 22px; font-weight: bold; text-decoration: underline;'>", 
+        click_info$data$YEAR[1], ':', "</span><br>",
+        pp_vol_tooltip)))
+  })
+  
+  
+  
+  #' *Processed Product Price*
+  pp_price_clicked_point <- reactiveVal(NULL)
+  
+  observeEvent(input$pp_price_plot_click, {
+    click_x <- input$pp_price_plot_click$x
+    
+    pp_data <- pp_df()
+    
+    year_levels <- levels(factor(sort(unique(pp_data$YEAR))))
+    clicked_year <- round(click_x)
+    
+    if (clicked_year >= 1 && clicked_year <= length(year_levels)) {
+      clicked_factor_year <- year_levels[clicked_year]
+      
+      click_point <- pp_data[pp_data$YEAR == clicked_factor_year, ]
+      
+      pp_price_clicked_point(list(
+        data = click_point,
+        coords_css = input$pp_price_plot_click$coords_css))
+    } else {
+      pp_price_clicked_point(NULL)
+    }
+  })
+  
+  observeEvent(input$close_pp_price_tooltip, {
+    pp_price_clicked_point(NULL)
+  })
+  
+  output$pp_price_click_overlay <- renderUI({
+    click_info <- pp_price_clicked_point()
+    
+    if (is.null(click_info)) {
+      return(NULL)
+    }
+    
+    # SPECIFY GROUPS
+    # First, get data
+    pp_data <- pp_df()
+    
+    # get the low proportions embedded in pp plot function
+    low_prop_types_value <- pp_data %>% 
+      select(PP_VALUE_BILLIONS_2024USD, PRODUCT_NAME) %>%
+      group_by(PRODUCT_NAME) %>%
+      summarise(across(where(is.numeric), sum),
+                .groups = 'drop') %>%
+      mutate(TOTAL_VALUE = sum(PP_VALUE_BILLIONS_2024USD),
+             VALUE_SHARE = PP_VALUE_BILLIONS_2024USD / TOTAL_VALUE) %>%
+      filter(VALUE_SHARE < 0.02) %>%
+      select(PRODUCT_NAME)
+    
+    low_prop_types_volume <- pp_data %>%
+      select(PP_VOLUME_MT, PRODUCT_NAME) %>%
+      group_by(PRODUCT_NAME) %>%
+      summarise(across(where(is.numeric), sum),
+                .groups = 'drop') %>%
+      mutate(TOTAL_VOLUME = sum(PP_VOLUME_MT),
+             VOLUME_SHARE = PP_VOLUME_MT / TOTAL_VOLUME) %>%
+      filter(VOLUME_SHARE < 0.02) %>%
+      select(PRODUCT_NAME)
+    
+    low_prop_types <- bind_rows(low_prop_types_value, low_prop_types_volume) %>%
+      distinct() %>%
+      pull(PRODUCT_NAME)
+    
+    # rename these low proportion types as 'OTHER*' and re-summarise
+    new_data <- pp_data %>%
+      mutate(PRODUCT_NAME = ifelse(PRODUCT_NAME %in% c('OTHER', low_prop_types),
+                                   'OTHER*', PRODUCT_NAME)) %>%
+      group_by(YEAR, PRODUCT_NAME) %>%
+      summarise(across(where(is.numeric), sum),
+                .groups = 'drop') %>%
+      mutate(PP_PRICE_2024USD_PER_KG = PP_VALUE_2024USD / PP_VOLUME_KG,
+             PP_PRICE_2024USD_PER_LB = PP_VALUE_2024USD / PP_VOLUME_LB,
+             PP_VOLUME_THOUSAND_MT = PP_VOLUME_MT / 1000,
+             PP_VOLUME_THOUSAND_ST = PP_VOLUME_ST / 1000,
+             PP_NOMINAL_PRICE_2024USD_PER_KG = PP_NOMINAL_VALUE / PP_VOLUME_KG,
+             PP_NOMINAL_PRICE_2024USD_PER_LB = PP_NOMINAL_VALUE / PP_VOLUME_LB)
+    
+    # Next, get product forms
+    products <- unique(str_to_title(new_data$PRODUCT_NAME))
+    # Subset colors for these products
+    pp_colors <- colors[names(colors) %in% products]
+    pp_colors <- pp_colors[order(names(pp_colors))]
+    
+    filtered_new_data <- new_data %>% 
+      filter(YEAR == click_info$data$YEAR[1]) %>%
+      arrange(PRODUCT_NAME)
+    
+    # create icons (number will vary)
+    # begin with empty vector that will ultimately contain the full HTML code
+    pp_price_tooltip <- vector()
+    for (i in 1:length(pp_colors)) {
+      tooltip_icon <- paste0(
+        '<img src = "', create_tooltip_icon(pp_colors[i], 16), 
+        '" class = "tooltip-icon" alt = "legend icon"/>')
+      
+      tooltip_text <- paste0(
+        "</span><span style = 'font-size: 18px; font-style: italic; text-decoration: underline;'>",
+        names(pp_colors)[i], "</span>: ")
+      
+      tooltip_data <- paste0(
+        dollar(filtered_new_data$PP_PRICE_2024USD_PER_KG[i]), " per kilogram <br>"
+      )
+      
+      pp_price_tooltip <- paste0(pp_price_tooltip, 
+                                 tooltip_icon, tooltip_text, tooltip_data)
+    }
+    
+    # Position tooltip near clicked point
+    left_pos <- click_info$coords_css$x + 20 # Offset to right of point
+    top_pos <- click_info$coords_css$y - 20 # Offset above point
+    
+    # Prevent tooltip from being off screen
+    left_pos <- max(10, left_pos)
+    top_pos <- max(10, top_pos)
+    
+    # style the tooltip for clicked point
+    div(
+      style = paste0(
+        "left: ", left_pos, "px;",
+        "top: ", top_pos, "px;",
+        tooltip_aes,
+        "max-width: 375px; ",
+        "min-width: 375px; "),
+      # tooltip close button
+      tags$button(
+        "x",
+        id = 'close_pp_price_tooltip',
+        onclick = "Shiny.setInputValue('close_pp_price_tooltip', Math.random());",
+        style = close_button_aes), 
+      HTML(paste0(
+        "<span style = 'font-size: 22px; font-weight: bold; text-decoration: underline;'>", 
+        click_info$data$YEAR[1], ':', "</span><br>",
+        pp_price_tooltip)))
+  })
 }
 
 # Run the app


### PR DESCRIPTION
This pull overhauls the UI structure embedded in the code while offering minimal visual changes to the user. Initially, plotly was identified as a suitable package that could satisfy the function to pop-up data information for users based on where they guided the mouse pointer. However, limitations in plotly's cooperation with ggplot as well as its ability to incorporate legend icons in tooltips motivated a shift away from plotly towards ggplot and shiny features that provide more flexibility in how to present tooltips organically within the shiny framework. While this requires some knowledge of css and HTML code language, ultimately this is the current best format to present tooltips to users and minimal knowledge of these languages is necessary for execution here.

Importantly, while this pull satisfies the issue, an important tertiary issue has arisen as a result of this effort. Specifically, the app uses custom functions that summarize data for plots and plot the summarized data. Often, the plotting functions engage in further data munging which causes some headaches with presenting accurate information in the tooltips; this is because the tooltips rely on outputs from the summarization functions whose data is less munged, at times, than that displayed from the plot functions. The resolution to this error lies in shifting any data munging from the plot functions back to the summarizing functions. This will also fix the issue of tooltips presently not being able to handle user changes from imperial to metric units nor nominal to adjusted dollars. 