### PR TITLE
70 add conversion factor for weight data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ pp_hts_mismatches.xlsx
 *.png
 *.xlsx
 city_region.R
+*.pdf

--- a/1_data_pulls.R
+++ b/1_data_pulls.R
@@ -274,6 +274,10 @@ florida_coast_map <- read.csv('florida_city_map.csv')
 # map to assign great lakes cities
 great_lakes_cities <- read.csv('gl_border_state_cities.csv')
 
+# conversion factor map
+conversion_factors <- read.csv('conversion_factors/conversion_factors.csv') %>%
+  select(HTS_NUMBER, CF)
+
 #####################
 ### SAVE THE DATA ###
 #####################
@@ -287,7 +291,8 @@ file_name <- paste0('seafood_trade_data_pull_',
   # NOTE: add new data to this list upon creation in this script
 save(list = c('foss_exports', 'foss_imports', 'pp_processed', 'def_index',
               'species_ref', 'foss_com_landings', 'florida_coast_map',
-              'great_lakes_cities', 'trade_map', 'landings_map', 'pp_map'),
+              'great_lakes_cities', 'trade_map', 'landings_map', 'pp_map',
+              'conversion_factors'),
      file = file_name)
 
 # upload to google drive

--- a/2_data_munge.R
+++ b/2_data_munge.R
@@ -104,7 +104,11 @@ exports <- foss_exports %>%
     # We calculated the Index value in script 1
   left_join(def_index %>% select(YEAR, INDEX)) %>%
   mutate(EXP_VALUE_2024USD = VALUE_USD * INDEX) %>%
-  select(-INDEX)
+  select(-INDEX) %>%
+  left_join(conversion_factors %>%
+              mutate(HTS_NUMBER = as.character(HTS_NUMBER))) %>%
+  mutate(CF = ifelse(is.na(CF), 1, CF),
+         CONVERTED_VOLUME = VOLUME_KG * CF)
 
 
 # Data summarizing
@@ -125,8 +129,8 @@ exports_products_smry <- exports %>%
   # country name (exported to), customs district (exported from)
 exports_price_smry <- exports %>%
   select(YEAR, CONTINENT, COUNTRY_NAME, US_CUSTOMS_DISTRICT, STATE, FAO_COUNTRY_CODE,
-         VALUE_USD, EXP_VALUE_2024USD, VOLUME_KG, GROUP_NAME, GROUP_TS, 
-         GROUP_CBP, SPECIES_NAME, SPECIES_GROUP, SPECIES_CATEGORY,
+         VALUE_USD, EXP_VALUE_2024USD, VOLUME_KG, CONVERTED_VOLUME, GROUP_NAME, 
+         GROUP_TS, GROUP_CBP, SPECIES_NAME, SPECIES_GROUP, SPECIES_CATEGORY,
          ECOLOGICAL_CATEGORY) %>%
   group_by(YEAR, CONTINENT, COUNTRY_NAME, US_CUSTOMS_DISTRICT, STATE, 
            FAO_COUNTRY_CODE, GROUP_NAME, GROUP_TS, GROUP_CBP, SPECIES_NAME,
@@ -161,7 +165,11 @@ imports <- foss_imports %>%
   left_join(def_index %>% select(YEAR, INDEX)) %>%
   mutate(IMP_VALUE_2024USD = VALUE_USD * INDEX,
          IMP_CALCULATED_DUTY_2024USD = CALCULATED_DUTY_USD * INDEX) %>%
-  select(-INDEX)
+  select(-INDEX) %>%
+  left_join(conversion_factors %>%
+              mutate(HTS_NUMBER = as.character(HTS_NUMBER))) %>%
+  mutate(CF = ifelse(is.na(CF), 1, CF),
+         CONVERTED_VOLUME = VOLUME_KG * CF)
   
 
 # Data summarizing
@@ -177,7 +185,7 @@ imports_products_smry <- imports %>%
 
 imports_price_smry <- imports %>%
   select(YEAR, CONTINENT, COUNTRY_NAME, US_CUSTOMS_DISTRICT, STATE, FAO_COUNTRY_CODE,
-         VALUE_USD, VOLUME_KG, IMP_VALUE_2024USD, CALCULATED_DUTY_USD,
+         VALUE_USD, VOLUME_KG, CONVERTED_VOLUME, IMP_VALUE_2024USD, CALCULATED_DUTY_USD,
          IMP_CALCULATED_DUTY_2024USD, GROUP_NAME, GROUP_TS, GROUP_CBP,
          SPECIES_NAME, SPECIES_GROUP, SPECIES_CATEGORY, ECOLOGICAL_CATEGORY) %>%
   group_by(YEAR, CONTINENT, COUNTRY_NAME, US_CUSTOMS_DISTRICT, STATE,
@@ -200,11 +208,13 @@ imports_smry <- full_join(imports_products_smry, imports_price_smry)
 # We need to change column names to coerce their join properly
 exports_smry <- exports_smry %>%
   rename(EXP_VALUE_USD = VALUE_USD,
-         EXP_VOLUME_KG = VOLUME_KG)
+         EXP_VOLUME_KG = VOLUME_KG,
+         EXP_CONVERTED_VOLUME = CONVERTED_VOLUME)
 
 imports_smry <- imports_smry %>%
   rename(IMP_VALUE_USD = VALUE_USD,
-         IMP_VOLUME_KG = VOLUME_KG) 
+         IMP_VOLUME_KG = VOLUME_KG,
+         IMP_CONVERTED_VOLUME = CONVERTED_VOLUME) 
 # calculated_duty_usd is unique to imports, so no need to change name
 
 # full_join the tables to account for countries or customs districts that 

--- a/conversion_factors/hts_to_cn8.R
+++ b/conversion_factors/hts_to_cn8.R
@@ -1,0 +1,1401 @@
+# Attempt to Consolidate Conversion Factor data
+# Author: Cameron Van Horn
+#         cameron.vanhorn@noaa.gov
+
+# The code below heavily relies on code curated by Kaitlyn Malakoff and Kailin
+  # Kroetz (https://github.com/kaitlyn-c-lee/seafood-traceability-design/tree/main)
+  # in the file 'Linkage_HTS_CN8.R'
+# The purpose here is to match CN-8 codes to HTS codes in NOAA trade data; a 
+  # bulk of this effort was performed by Malakoff and Kroetz as mentioned. However,
+  # their species attribution is unique to ours, thus some manual effort was 
+  # needed to ensure accurate attribution of CN-8 codes to HTS codes. 
+
+# BEFORE RUNNING: 
+  # Check if species classifications changed 
+  # Check if data from foss changed
+# Packages and Data ------------------------------------------------------------
+library(tidyverse)
+library(readxl)
+
+# Get Export and Import data from FOSS
+# Exports
+# read csv's
+foss_exports_1524 <- read.csv('foss_exports_15-24.csv') %>%
+  # use setNames from 'stats' to assign first row values as column names
+  setNames(.[1, ]) %>%
+  rename_with( ~ toupper(gsub(' ', '_', .x, fixed = T))) %>%
+  rename_with( ~ toupper(gsub('(', '', .x, fixed = T))) %>%
+  rename_with( ~ toupper(gsub(')', '', .x, fixed = T))) %>%
+  # remove first row
+  .[-1, ] %>%
+  # HTS_NUMBER, which is the key to attach species information, is not properly
+  # formatted as some keys have an incorrect leading '0'
+  # Remove the leading 0 from any keys containing one
+  # set ifelse such that if the first character in HTS_NUMBER == 0, it is
+  # removed from the string
+  mutate(HTS_NUMBER = ifelse(str_sub(HTS_NUMBER, 1, 1) == '0',
+                             str_sub(HTS_NUMBER, 2, -1),
+                             HTS_NUMBER),
+         STATE = substr(US_CUSTOMS_DISTRICT, nchar(US_CUSTOMS_DISTRICT) - 1,
+                        nchar(US_CUSTOMS_DISTRICT)),
+         STATE = ifelse(STATE %in% c('NT', 'DS'), NA, STATE),
+         US_CUSTOMS_DISTRICT = ifelse(is.na(STATE), US_CUSTOMS_DISTRICT,
+                                      substr(US_CUSTOMS_DISTRICT, 0, nchar(US_CUSTOMS_DISTRICT) - 4)))
+
+foss_exports_0414 <- read.csv('foss_exports_04-14.csv') %>%
+  setNames(.[1, ]) %>%
+  rename_with( ~ toupper(gsub(' ', '_', .x, fixed = T))) %>%
+  rename_with( ~ toupper(gsub('(', '', .x, fixed = T))) %>%
+  rename_with( ~ toupper(gsub(')', '', .x, fixed = T))) %>%
+  .[-1, ] %>%
+  mutate(HTS_NUMBER = ifelse(str_sub(HTS_NUMBER, 1, 1) == '0',
+                             str_sub(HTS_NUMBER, 2, -1),
+                             HTS_NUMBER),
+         STATE = substr(US_CUSTOMS_DISTRICT, nchar(US_CUSTOMS_DISTRICT) - 1,
+                        nchar(US_CUSTOMS_DISTRICT)),
+         STATE = ifelse(STATE %in% c('NT', 'DS'), NA, STATE),
+         US_CUSTOMS_DISTRICT = ifelse(is.na(STATE), US_CUSTOMS_DISTRICT,
+                                      substr(US_CUSTOMS_DISTRICT, 0, nchar(US_CUSTOMS_DISTRICT) - 4)))
+
+# combine data (stack)
+foss_exports <- bind_rows(foss_exports_0414, foss_exports_1524)
+
+# Imports
+# read csv's
+foss_imports_1524 <- read.csv('foss_imports_15-24.csv') %>%
+  setNames(.[1, ]) %>%
+  rename_with( ~ toupper(gsub(' ', '_', .x, fixed = T))) %>%
+  rename_with( ~ toupper(gsub('(', '', .x, fixed = T))) %>%
+  rename_with( ~ toupper(gsub(')', '', .x, fixed = T))) %>%
+  .[-1, ] %>%
+  mutate(HTS_NUMBER = ifelse(str_sub(HTS_NUMBER, 1, 1) == '0',
+                             str_sub(HTS_NUMBER, 2, -1),
+                             HTS_NUMBER),
+         STATE = substr(US_CUSTOMS_DISTRICT, nchar(US_CUSTOMS_DISTRICT) - 1,
+                        nchar(US_CUSTOMS_DISTRICT)),
+         STATE = ifelse(STATE %in% c('NT', 'DS'), NA, STATE),
+         US_CUSTOMS_DISTRICT = ifelse(is.na(STATE), US_CUSTOMS_DISTRICT,
+                                      substr(US_CUSTOMS_DISTRICT, 0, nchar(US_CUSTOMS_DISTRICT) - 4)))
+
+foss_imports_0414 <- read.csv('foss_imports_04-14.csv') %>%
+  setNames(.[1, ]) %>%
+  rename_with( ~ toupper(gsub(' ', '_', .x, fixed = T))) %>%
+  rename_with( ~ toupper(gsub('(', '', .x, fixed = T))) %>%
+  rename_with( ~ toupper(gsub(')', '', .x, fixed = T))) %>%
+  .[-1, ] %>%
+  mutate(HTS_NUMBER = ifelse(str_sub(HTS_NUMBER, 1, 1) == '0',
+                             str_sub(HTS_NUMBER, 2, -1),
+                             HTS_NUMBER),
+         STATE = substr(US_CUSTOMS_DISTRICT, nchar(US_CUSTOMS_DISTRICT) - 1,
+                        nchar(US_CUSTOMS_DISTRICT)),
+         STATE = ifelse(STATE %in% c('NT', 'DS'), NA, STATE),
+         US_CUSTOMS_DISTRICT = ifelse(is.na(STATE), US_CUSTOMS_DISTRICT,
+                                      substr(US_CUSTOMS_DISTRICT, 0, nchar(US_CUSTOMS_DISTRICT) - 4)))
+
+# combine data (stack)
+foss_imports <- bind_rows(foss_imports_0414, foss_imports_1524)
+
+rm(foss_exports_0414, foss_exports_1524, foss_imports_0414, foss_imports_1524)
+
+
+# Get EUMOFA data
+eumofa <- read_excel("DM_Annex 7 - CF by CN-8 from 2001 to 2021.xlsx",
+                     sheet = "List of CF")
+# use most recent cn-8 codes
+eumofa <- eumofa %>% 
+  filter(Year == '2021') %>%
+  # select relevant columns
+  select(`CN-8`, `CN-8 product name`, CF, Explanation) %>%
+  # remove gaps in Cn-8 codes
+  mutate(`CN-8` = str_remove_all(`CN-8`, " "))
+
+
+# get species mapping sheet
+trade_map <- read.csv('trade_data_mapping_sheet.csv') %>%
+  mutate(HTS_NUMBER = as.character(HTS_NUMBER))
+
+# Create a Map -----------------------------------------------------------------
+# combine imports and exports
+trade_data <- rbind(foss_exports, foss_imports) %>%
+  # attach species groups
+  left_join(trade_map %>%
+              # keep only species categories
+              select(PRODUCT_NAME, HTS_NUMBER, SPECIES_NAME, SPECIES_GROUP, 
+                     SPECIES_CATEGORY, ECOLOGICAL_CATEGORY))
+
+# get map of products/hts codes by classifications
+us_hts_cn8 <- trade_data %>%
+  select(HTS_NUMBER, PRODUCT_NAME, SPECIES_NAME, SPECIES_GROUP,
+         SPECIES_CATEGORY, ECOLOGICAL_CATEGORY) %>%
+  distinct() %>%
+  mutate(SPECIES_NAME = ifelse(is.na(SPECIES_NAME), '', SPECIES_NAME),
+         SPECIES_GROUP = ifelse(is.na(SPECIES_GROUP), '', SPECIES_GROUP),
+         SPECIES_CATEGORY = ifelse(is.na(SPECIES_CATEGORY), '', SPECIES_CATEGORY),
+         ECOLOGICAL_CATEGORY = ifelse(is.na(ECOLOGICAL_CATEGORY), '', ECOLOGICAL_CATEGORY))
+
+# Attach CN-8 codes to HTS -----------------------------------------------------
+# create empty column for cn8 codes
+us_hts_cn8$`CN-8` <- ''
+
+# abalone
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'ABALONE', '03078100', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'ABALONE' &
+                           (str_detect(PRODUCT_NAME, 'FROZEN') | str_detect(PRODUCT_NAME, 'DRIED/SALTED/BRINE')),
+                         '03078300', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'ABALONE' &
+                           (str_detect(PRODUCT_NAME, 'PREPAR') | str_detect(PRODUCT_NAME, 'CANNED')),
+                         '16055700', `CN-8`))
+
+# anchovy
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'ANCHOVY', '03024200', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'ANCHOVY' &
+                           (str_detect(PRODUCT_NAME, 'SALTED')),
+                         '03056300', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'ANCHOVY' &
+                           (str_detect(PRODUCT_NAME, 'CANNED') | str_detect(PRODUCT_NAME, 'PREPAR')),
+                         '16041600', `CN-8`))
+
+# atka mackerel, use mackerel codes
+us_hts_cn8 <- us_hts_cn8 %>% 
+  mutate(`CN-8` = if_else(SPECIES_NAME == 'ATKA MACKEREL', '03024400', `CN-8`),
+         `CN-8` = if_else(SPECIES_NAME == 'ATKA MACKEREL' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'),
+                         '03035410', `CN-8`))
+
+# bass
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'SEA BASS', '03028410', `CN-8`))
+
+# bonito
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'BONITO', '16041490', `CN-8`))
+
+# butterfish (use mackerel)
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'BUTTERFISH', '03035410', `CN-8`))
+
+# capelin
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_NAME == 'CAPELIN', '03035990', `CN-8`))
+
+# carp
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'CARP', '03027300', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'CARP' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'),
+                         '03032500', `CN-8`))
+
+# species unident., include carp (check 8 digit codes in eumofa)
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(HTS_NUMBER %in% c('304390000'), '03043900', `CN-8`),
+         `CN-8` = ifelse(HTS_NUMBER %in% c('304510090', '304510190', '304510000', '304510100'), 
+                         '03045100', `CN-8`),
+         `CN-8` = ifelse(HTS_NUMBER %in% c('304690000'), '03046900', `CN-8`),
+         `CN-8` = ifelse(HTS_NUMBER %in% c('304931005', '304931010', '304931090'),
+                         '03049310', `CN-8`),
+         `CN-8` = ifelse(HTS_NUMBER %in% c('304939000'), '03049390', `CN-8`),
+         `CN-8` = ifelse(HTS_NUMBER %in% c('305310100', '305310000'), 
+                         '03053100', `CN-8`),
+         `CN-8` = ifelse(HTS_NUMBER %in% c('305440000', '305440100'), 
+                         '03054490', `CN-8`),
+         `CN-8` = ifelse(HTS_NUMBER %in% c('305641000', '305645000', '305640000'),
+                         '03056400', `CN-8`),
+         `CN-8` = ifelse(HTS_NUMBER %in% c('305520000'), '03053100', `CN-8`),
+         `CN-8` = ifelse(HTS_NUMBER %in% c('304930000'), '03049390', `CN-8`))
+
+# catfish
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'CATFISH', '03027200', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'CATFISH' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'),
+                         '03032400', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'CATFISH' &
+                           str_detect(PRODUCT_NAME, 'FILLET'), 
+                         '03043900', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'CATFISH' &
+                           str_detect(PRODUCT_NAME, 'FROZEN') &
+                           str_detect(PRODUCT_NAME, 'FILLET'),
+                         '03046900', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'CATFISH' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), 
+                         '03045100', `CN-8`))
+
+# clam
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'CLAM', '16055600', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'CLAM' &
+                           (str_detect(PRODUCT_NAME, 'FROZEN') |
+                              str_detect(PRODUCT_NAME, 'DRIED/SALTED/BRINE')),
+                         '03077900', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'CLAM' &
+                           (str_detect(PRODUCT_NAME, 'LIVE') |
+                              str_detect(PRODUCT_NAME, 'FRESH')), 
+                         '03077100', `CN-8`))
+
+# some unident. species matched using codes
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(HTS_NUMBER %in% c('1605560500'), '16055600', `CN-8`))
+
+# cobia
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'COBIA', '03024600', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'COBIA' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), 
+                         '03035600', `CN-8`),
+         `CN-8` = ifelse(HTS_NUMBER %in% c('305540000'), '03055490', `CN-8`))
+
+# conch
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'CONCH', '03078200', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'CONCH' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), 
+                         '03078400', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'CONCH' &
+                           str_detect(PRODUCT_NAME, 'DRIED/SALTED/BRINE'), 
+                         '03078800', `CN-8`))
+
+# crab
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_CATEGORY == 'CRABS', '03063390', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'CRABS' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'),
+                         '03061490', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'CRABS' & 
+                           (str_detect(PRODUCT_NAME, 'PREPAR') |
+                              str_detect(PRODUCT_NAME, 'ATC') |
+                              str_detect(PRODUCT_NAME, 'CANNED')),
+                         '16051000', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'CRABS' &
+                           str_detect(PRODUCT_NAME, 'MEAT'),
+                         '16051000', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'CRABS' &
+                           str_detect(PRODUCT_NAME, 'DRIED/SALTED/BRINE'), 
+                         '03069390', `CN-8`))
+
+# snow and king crab
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse((SPECIES_NAME == 'SNOW CRAB' |
+                           SPECIES_NAME == 'KING CRAB') &
+                           str_detect(PRODUCT_NAME, 'FROZEN') &
+                           !str_detect(PRODUCT_NAME, 'MEAT'), '03061410', `CN-8`))
+
+# crayfish
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'CRAYFISH', '03061910', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'CRAYFISH' &
+                           str_detect(PRODUCT_NAME, 'PEELED'), '16054000', `CN-8`))
+
+# cuttlefish
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'CUTTLEFISH', '03074290', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'CUTTLEFISH' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03074399', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'CUTTLEFISH' &
+                           str_detect(PRODUCT_NAME, 'PREPAR'), '16055400', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'CUTTLEFISH' & 
+                           str_detect(PRODUCT_NAME, 'DRIED/SALTED/BRINE'), '03074980', `CN-8`),
+         `CN-8` = ifelse(HTS_NUMBER %in% c('1605540500'), '16055400', `CN-8`))
+
+# dolphinfish (in EUMOFA its longfinned tunas)
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'DOLPHINFISH', '03023190', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'DOLPHINFISH' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03048990', `CN-8`))
+
+# eels
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'EEL', '03027400', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'EEL' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03032600', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'EEL' &
+                           (str_detect(PRODUCT_NAME, 'OIL') |
+                              str_detect(PRODUCT_NAME, 'PREPAR')), '16041700', `CN-8`))
+
+# flounder
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'FLOUNDER', '03022980', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'FLOUNDER' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03033910', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'FLOUNDER' &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044300', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'FLOUNDER' &
+                           str_detect(PRODUCT_NAME, 'FROZEN') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03048330', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'FLOUNDER' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045990', `CN-8`))
+
+# halibut
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'HALIBUT', '03022110', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HALIBUT' &
+                           str_detect(PRODUCT_NAME, 'ATLANTIC'), '03022130', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HALIBUT' &
+                           str_detect(PRODUCT_NAME, 'PACIFIC'), '03022190', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HALIBUT' &
+                           str_detect(PRODUCT_NAME, 'ATLANTIC') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03033130', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HALIBUT' &
+                           str_detect(PRODUCT_NAME, 'PACIFIC') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03033190', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HALIBUT' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03033110', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HALIBUT' &
+                           str_detect(PRODUCT_NAME, 'FROZEN') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03048390', `CN-8`))
+
+# plaice
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'PLAICE', '03022200', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'PLAICE' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03033200', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'PLAICE' &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03048310', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'PLAICE' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045990', `CN-8`))
+
+# Sole
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'SOLE', '03022300', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SOLE' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03033300', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SOLE' &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044300', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SOLE' &
+                           str_detect(PRODUCT_NAME, 'FROZEN') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03048390', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SOLE' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045990', `CN-8`))
+
+# turbot
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'TURBOT', '03022400', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'TURBOT' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03033400', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'TURBOT' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045990', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'TURBOT' &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044300', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'TURBOT' &
+                           str_detect(PRODUCT_NAME, 'FROZEN') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03048390', `CN-8`))
+
+# other flatfishes
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_CATEGORY == 'FLATFISHES' &
+                           SPECIES_GROUP == '', '03022980', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'FLATFISHES' &
+                           SPECIES_GROUP == '' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03033985', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'FLATFISHES' &
+                           SPECIES_GROUP == '' &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044300', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'FLATFISHES' &
+                           SPECIES_GROUP == '' &
+                           str_detect(PRODUCT_NAME, 'FROZEN') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03048390', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'FLATFISHES' &
+                           SPECIES_GROUP == '' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045990', `CN-8`))
+
+# cod
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'COD', '03025190', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'COD' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03036390', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'COD' &
+                           str_detect(PRODUCT_NAME, 'ATLANTIC'), '03025110', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'COD' &
+                           str_detect(PRODUCT_NAME, 'FROZEN') &
+                           str_detect(PRODUCT_NAME, 'ATLANTIC'), '03036310', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'COD' &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044410', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'COD' &
+                           str_detect(PRODUCT_NAME, 'DRIED'), '03055110', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'COD' &
+                           str_detect(PRODUCT_NAME, 'SALTED'), '03055190', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'COD' &
+                           str_detect(PRODUCT_NAME, 'FROZEN') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03047190', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'COD' &
+                           str_detect(PRODUCT_NAME, 'SALTED') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03053219', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'COD' &
+                           str_detect(PRODUCT_NAME, 'DRIED') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03053219', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'COD' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045300', `CN-8`),
+         `CN-8` = ifelse(ECOLOGICAL_CATEGORY == 'GROUNDFISHES' &
+                           str_detect(PRODUCT_NAME, 'SMOKED'), '03054980', `CN-8`))
+
+# cusk
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'CUSK', '03025940', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'CUSK' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03036980', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'CUSK' &
+                           str_detect(PRODUCT_NAME, 'SALTED'), '03056910', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'CUSK' &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044990', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'CUSK' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045990', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'CUSK' &
+                           str_detect(PRODUCT_NAME, 'FROZEN') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03047980', `CN-8`))
+
+# haddock
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'HADDOCK', '03025200', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HADDOCK' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03036400', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HADDOCK' &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044490', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HADDOCK' &
+                           str_detect(PRODUCT_NAME, 'FILLET') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03047200', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HADDOCK' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03049530', `CN-8`))
+
+# hake (there doesn't seem to be any frozen hake that isn't fillets)
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'HAKE', '03025419', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HAKE' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03036619', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HAKE' &
+                           str_detect(PRODUCT_NAME, 'SALTED'), '03056910', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'POLLOCK AND HAKE' &
+                           SPECIES_GROUP == '' &
+                           str_detect(PRODUCT_NAME, 'SALTED'), '03056910', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HAKE' &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044490', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HAKE' &
+                           str_detect(PRODUCT_NAME, 'FILLET') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03047419', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HAKE' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03049550', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HAKE' &
+                           str_detect(PRODUCT_NAME, 'FILLET') &
+                           str_detect(PRODUCT_NAME, 'FROZEN') &
+                           str_detect(PRODUCT_NAME, 'UROPHYCIS'), '03047490', `CN-8`))
+         
+# ocean perch
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(str_detect(PRODUCT_NAME, 'OCEAN PERCH'), '03028939', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'OCEAN PERCH') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03038939', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'OCEAN PERCH') &
+                           str_detect(PRODUCT_NAME, 'ATLANTIC'), '03028931', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'OCEAN PERCH') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044950', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'OCEAN PERCH') &
+                           str_detect(PRODUCT_NAME, 'ATLANTIC') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03038931', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'OCEAN PERCH') &
+                           str_detect(PRODUCT_NAME, 'ATLANTIC') &
+                           str_detect(PRODUCT_NAME, 'FROZEN') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03048921', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'OCEAN PERCH') &
+                           str_detect(PRODUCT_NAME, 'FROZEN') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03048929', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'OCEAN PERCH') &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03049929', `CN-8`))
+
+# pollock (no canned pollock, but some canned pollock + other fish)
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'POLLOCK', '03025930', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'POLLOCK' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03036950', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'POLLOCK' &
+                           str_detect(PRODUCT_NAME, 'ALASKA'), '03025500', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'POLLOCK' &
+                           str_detect(PRODUCT_NAME, 'ALASKA') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03036700', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'POLLOCK' &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044490', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'POLLOCK' &
+                           str_detect(PRODUCT_NAME, 'ALASKA') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03047500', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'POLLOCK' &
+                           str_detect(PRODUCT_NAME, 'ALASKA') &
+                           (str_detect(PRODUCT_NAME, 'SURIMI') |
+                              str_detect(PRODUCT_NAME, 'MINCED')), '03049410', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'POLLOCK' &
+                           str_detect(PRODUCT_NAME, 'CANNED'), '16041995', `CN-8`), # none
+         `CN-8` = ifelse(SPECIES_GROUP == 'POLLOCK' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03049490', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'POLLOCK' &
+                           str_detect(PRODUCT_NAME, 'SALTED') &
+                           !str_detect(PRODUCT_NAME, 'FILLET'), '03056910', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'POLLOCK' &
+                           str_detect(PRODUCT_NAME, 'FRESH') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044490', `CN-8`))
+
+# whiting and blue whiting
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_NAME == 'BLUE WHITING', '03025600', `CN-8`),
+         `CN-8` = ifelse(SPECIES_NAME == 'BLUE WHITING' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03036810', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'WHITING' &
+                           SPECIES_NAME == '', '03047930', `CN-8`))
+
+# other groundfish
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(ECOLOGICAL_CATEGORY == 'GROUNDFISHES' & 
+                           SPECIES_CATEGORY == '', '03025990', `CN-8`),
+         `CN-8` = ifelse(ECOLOGICAL_CATEGORY == 'GROUNDFISHES' &
+                           SPECIES_CATEGORY == '' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03036990', `CN-8`),
+         `CN-8` = ifelse(ECOLOGICAL_CATEGORY == 'GROUNDFISHES' &
+                           SPECIES_CATEGORY == '' &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044490', `CN-8`),
+         `CN-8` = ifelse(ECOLOGICAL_CATEGORY == 'GROUNDFISHES' &
+                           SPECIES_CATEGORY == '' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045300', `CN-8`),
+         `CN-8` = ifelse(ECOLOGICAL_CATEGORY == 'GROUNDFISHES' &
+                           SPECIES_CATEGORY == '' &
+                           str_detect(PRODUCT_NAME, 'SURIMI'), '03049510', `CN-8`),
+         `CN-8` = ifelse(ECOLOGICAL_CATEGORY == 'GROUNDFISHES' &
+                           SPECIES_CATEGORY == '' &
+                           str_detect(PRODUCT_NAME, 'DRIED'), '03055390', `CN-8`),
+         `CN-8` = ifelse(ECOLOGICAL_CATEGORY == 'GROUNDFISHES' &
+                           SPECIES_CATEGORY == '' &
+                           str_detect(PRODUCT_NAME, 'DRIED') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03053290', `CN-8`),
+         `CN-8` = ifelse(ECOLOGICAL_CATEGORY == 'GROUNDFISHES' &
+                           SPECIES_CATEGORY == '' &
+                           str_detect(PRODUCT_NAME, 'FROZEN') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03047990', `CN-8`))
+
+# grouper
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'GROUPER', '03025190', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'GROUPER' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03036390', `CN-8`))
+
+# herring
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'HERRING', '03024100', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HERRING' &
+                           str_detect(PRODUCT_NAME, 'SALTED'), '03056100', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HERRING' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03035100', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HERRING' &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03053990', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HERRING' &
+                           str_detect(PRODUCT_NAME, 'FILLET') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03048600', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HERRING' &
+                           str_detect(PRODUCT_NAME, 'SMOKED'), '03054200', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HERRING' &
+                           (str_detect(PRODUCT_NAME, 'PICKLED') |
+                              str_detect(PRODUCT_NAME, 'KIPPERED') |
+                              str_detect(PRODUCT_NAME, 'PREPAR')), '16041299', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HERRING' &
+                           (str_detect(PRODUCT_NAME, 'CANNED') |
+                              str_detect(PRODUCT_NAME, 'ATC')), '16041291', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'HERRING' &
+                           str_detect(PRODUCT_NAME, 'FILLET') &
+                           str_detect(PRODUCT_NAME, 'PICKLED'), '16041210', `CN-8`))
+
+# horse mackerel jacks
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(str_detect(PRODUCT_NAME, 'JACK,HORSE MACKEREL'), '03024590', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'JACK,HORSE MACKEREL') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03035590', `CN-8`))
+
+# jellyfish
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'JELLYFISH', '03083050', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'JELLYFISH' &
+                           str_detect(PRODUCT_NAME, 'PREPAR'), '16056300', `CN-8`))
+
+# krill
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'KRILL', '03063990', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'KRILL' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03061990', `CN-8`))
+
+# lingcod
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_NAME == 'LINGCOD', '03025190', `CN-8`))
+
+# lobster
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_CATEGORY == 'LOBSTERS', '03063210', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'LOBSTERS' &
+                           str_detect(PRODUCT_NAME, 'FRESH'), '03063291', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'LOBSTERS' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03061290', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'LOBSTERS' &
+                           (str_detect(PRODUCT_NAME, 'PREPAR') |
+                              str_detect(PRODUCT_NAME, 'TAILS') |
+                              str_detect(PRODUCT_NAME, 'CANNED')), '16053090', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'LOBSTERS' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '16053010', `CN-8`))
+
+# Homarus lobster
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_CATEGORY == 'LOBSTERS' &
+                           str_detect(PRODUCT_NAME, 'HOMARUS'), '03063291', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'LOBSTERS' &
+                           str_detect(PRODUCT_NAME, 'HOMARUS') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03061290', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'LOBSTERS' &
+                           str_detect(PRODUCT_NAME, 'HOMARUS') &
+                           str_detect(PRODUCT_NAME, 'LIVE'), '03063210', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'LOBSTERS' &
+                           str_detect(PRODUCT_NAME, 'HOMARUS') &
+                           (str_detect(PRODUCT_NAME, 'DRIED/SALTED/BRINE') |
+                              str_detect(PRODUCT_NAME, 'ATC')), '03069290', `CN-8`))
+
+# Norway lobster
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_CATEGORY == 'LOBSTERS' &
+                           str_detect(PRODUCT_NAME, 'NORWAY'), '03063400', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'LOBSTERS' &
+                           str_detect(PRODUCT_NAME, 'NORWAY') &
+                           str_detect(PRODUCT_NAME, 'DRIED/SALTED/BRINE'), '03069400', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'LOBSTERS' &
+                           str_detect(PRODUCT_NAME, 'NORWAY') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03061500', `CN-8`))
+
+# rock lobster
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_CATEGORY == 'LOBSTERS' &
+                           str_detect(PRODUCT_NAME, 'ROCK') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03061190', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'LOBSTERS' &
+                           str_detect(PRODUCT_NAME, 'ROCK') &
+                           str_detect(PRODUCT_NAME, 'DRIED/SALTED/BRINE'), '03069100', `CN-8`))
+
+# mackerel
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'MACKEREL', '03024400', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'MACKEREL' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03035410', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'MACKEREL' &
+                           str_detect(PRODUCT_NAME, 'SMOKED'), '03054930', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'MACKEREL' &
+                           str_detect(PRODUCT_NAME, 'SALTED'), '03056980', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'MACKEREL' &
+                           str_detect(PRODUCT_NAME, 'FILLET DRIED/SALTED/BRINE'), '16041511', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'MACKEREL' &
+                           (str_detect(PRODUCT_NAME, 'PREPAR') |
+                              str_detect(PRODUCT_NAME, 'CANNED')), '16041590', `CN-8`))
+
+# monkfish
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'MONKFISH', '03028950', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'MONKFISH' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03038965', `CN-8`))
+
+# mullet
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'MULLET', '03038990', `CN-8`))
+
+# mussels
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'MUSSEL', '03073190', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'MUSSEL' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03073290', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'MUSSEL' &
+                           str_detect(PRODUCT_NAME, 'PREPAR'), '16055390',`CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'MUSSEL' &
+                           str_detect(PRODUCT_NAME, 'DRIED/SALTED/BRINE'), '03073980', `CN-8`))
+
+# nile perch
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_NAME == 'NILE PERCH', '03027900', `CN-8`),
+         `CN-8` = ifelse(SPECIES_NAME == 'NILE PERCH' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03032900', `CN-8`),
+         `CN-8` = ifelse(SPECIES_NAME == 'NILE PERCH' &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03043300', `CN-8`),
+         `CN-8` = ifelse(SPECIES_NAME == 'NILE PERCH' &
+                           str_detect(PRODUCT_NAME, 'FILLET') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03046300', `CN-8`),
+         `CN-8` = ifelse(SPECIES_NAME == 'NILE PERCH' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045100', `CN-8`))
+
+# octopus
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'OCTOPUS', '03075100', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'OCTOPUS' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03075200', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'OCTOPUS' &
+                           str_detect(PRODUCT_NAME, 'PREPAR'), '16055500', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'OCTOPUS' &
+                           str_detect(PRODUCT_NAME, 'DRIED/SALTED/BRINE'), '03075900', `CN-8`))
+
+# orange roughy
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_NAME == 'ORANGE ROUGHY', '03048990', `CN-8`))
+
+# oysters
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'OYSTER', '03071190', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'OYSTER' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03071200', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'OYSTER' &
+                           (str_detect(PRODUCT_NAME, 'PREPAR') |
+                              str_detect(PRODUCT_NAME, 'CANNED')), '16055100', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'OYSTER' &
+                           str_detect(PRODUCT_NAME, 'DRIED/SALTED/BRINE'), '03071900', `CN-8`))
+
+# perch nspf
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'PERCH' &
+                           str_detect(PRODUCT_NAME, 'NSPF'), '03027900', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'PERCH' &
+                           str_detect(PRODUCT_NAME, 'NSPF') &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045990', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'PERCH' &
+                           str_detect(PRODUCT_NAME, 'NSPF') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03043900', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'PERCH' &
+                           str_detect(PRODUCT_NAME, 'NSPF') &
+                           str_detect(PRODUCT_NAME, 'FILLET') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03048990', `CN-8`))
+
+# pickerel
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'PICKEREL', '03027900', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'PICKEREL' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045990', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'PICKEREL' &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03043900', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'PICKEREL' &
+                           str_detect(PRODUCT_NAME, 'FILLET') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03048990', `CN-8`))
+
+# pike
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'PIKE', '03027900', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'PIKE' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045990', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'PIKE' &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044990', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'PIKE' &
+                           str_detect(PRODUCT_NAME, 'FILLET') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03048990', `CN-8`))
+
+# Rays (which includes skates)
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(str_detect(PRODUCT_NAME, 'RAYS'), '03028200', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'RAYS') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03038200', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'RAYS') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044800', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'RAYS') &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03049700', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'RAYS') &
+                           str_detect(PRODUCT_NAME, 'MEAT') &
+                           str_detect(PRODUCT_NAME, 'FRESH'), '03045700', `CN-8`))
+
+# sablefish
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_NAME == 'SABLEFISH', '03028990', `CN-8`),
+         `CN-8` = ifelse(SPECIES_NAME == 'SABLEFISH' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03038990', `CN-8`))
+
+# salmon (individual species later)
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_CATEGORY == 'SALMON', '03021900', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SALMON' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03031200', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SALMON' &
+                           (str_detect(PRODUCT_NAME, 'FILLET') |
+                              str_detect(PRODUCT_NAME, 'STEAKS')), '03044100', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SALMON' &
+                           (str_detect(PRODUCT_NAME, 'FILLET') |
+                              str_detect(PRODUCT_NAME, 'STEAKS')) &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03048100', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SALMON' &
+                           str_detect(PRODUCT_NAME, 'SALTED'), '03056950', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SALMON' &
+                           str_detect(PRODUCT_NAME, 'SMOKED'), '03054100', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SALMON' &
+                           str_detect(PRODUCT_NAME, 'CANNED'), '16041100', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SALMON' &
+                           str_detect(PRODUCT_NAME, 'PREPAR'), '16041100', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SALMON' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045200', `CN-8`))
+
+# atlantic/danube salmon
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'ATLANTIC SALMON', '03021400', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'ATLANTIC SALMON' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03031300', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'ATLANTIC SALMON' &
+                           (str_detect(PRODUCT_NAME, 'FILLET') |
+                              str_detect(PRODUCT_NAME, 'STEAK')), '03044100', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'ATLANTIC SALMON' &
+                           (str_detect(PRODUCT_NAME, 'FILLET') |
+                              str_detect(PRODUCT_NAME, 'STEAK')) &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03048100', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'ATLANTIC SALMON' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045200', `CN-8`))
+
+# sockeye salmon
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_NAME == 'SOCKEYE SALMON' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03031100', `CN-8`))
+
+# sardine
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'SARDINE', '03024330', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SARDINE' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03035330', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SARDINE' &
+                           str_detect(PRODUCT_NAME, 'CANNED'), '16041311', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SARDINE' &
+                           str_detect(PRODUCT_NAME, 'PREPAR'), '16041311', `CN-8`))
+
+# sauger
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_NAME == 'SAUGER', '03038910', `CN-8`),
+         `CN-8` = ifelse(SPECIES_NAME == 'SAUGER' &
+                           str_detect(PRODUCT_NAME, 'FILLET') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03048910', `CN-8`))
+
+# scallops
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'SCALLOP', '03072100', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SCALLOP' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03072290', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SCALLOP' &
+                           str_detect(PRODUCT_NAME, 'PREPAR'), '16055200', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SCALLOP' &
+                           str_detect(PRODUCT_NAME, 'DRIED/SALTED/BRINE'), '03072900', `CN-8`))
+
+# scorpionfish (use sea bass)
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'SCORPIONFISH', '03038490', `CN-8`))
+
+# sea bass
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'SEA BASS', '03028490', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SEA BASS' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03038490', `CN-8`))
+
+# sea cucumber
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'SEA CUCUMBER', '03081100', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SEA CUCUMBER' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03081200', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SEA CUCUMBER' &
+                           str_detect(PRODUCT_NAME, 'PREPAR'), '16056100', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SEA CUCUMBER' &
+                           str_detect(PRODUCT_NAME, 'DRIED/SALTED/BRINE'), '03081900', `CN-8`))
+
+# sea urchin
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'SEA URCHIN', '03082100', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SEA URCHIN' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03082200', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SEA URCHIN' &
+                           str_detect(PRODUCT_NAME, 'PREPAR'), '16056200', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SEA URCHIN' &
+                           str_detect(PRODUCT_NAME, 'DIRED/SALTED/BRINE'), '03082900', `CN-8`))
+
+# seabream
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(str_detect(PRODUCT_NAME, 'SEABREAM'), '03028590', `CN-8`))
+
+# shad
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(str_detect(PRODUCT_NAME, 'SHAD,STURGEON FRESH'), '03028990', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'SHAD,STURGEON FROZEN'), '03038990', `CN-8`))
+
+# shark
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_CATEGORY == 'SHARKS', '03028180', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SHARKS' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03038190', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SHARKS' &
+                           str_detect(PRODUCT_NAME, 'DOGFISH'), '03028115', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SHARKS' &
+                           str_detect(PRODUCT_NAME, 'DOGFISH') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03038115', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SHARKS' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03049690', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SHARKS' &
+                           str_detect(PRODUCT_NAME, 'FIN'), '03029200', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SHARKS' &
+                           str_detect(PRODUCT_NAME, 'FIN') &
+                           str_detect(PRODUCT_NAME, 'DRIED'), '03057100', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SHARKS' &
+                           str_detect(PRODUCT_NAME, 'FIN') &
+                           str_detect(PRODUCT_NAME, 'PREPAR'), '16041800', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SHARKS' &
+                           str_detect(PRODUCT_NAME, 'FIN') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03039200', `CN-8`),
+         `CN-8` = ifelse(HTS_NUMBER %in% c('304880000'), '03048819', `CN-8`))
+
+# shrimp
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_CATEGORY == 'SHRIMP', '03063690', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SHRIMP' &
+                           str_detect(PRODUCT_NAME, 'COLD-WATER'), '03063590', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SHRIMP' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03061799', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SHRIMP' &
+                           str_detect(PRODUCT_NAME, 'FROZEN') &
+                           str_detect(PRODUCT_NAME, 'COLD-WATER'), '03061699', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SHRIMP' &
+                           str_detect(PRODUCT_NAME, 'FROZEN') &
+                           str_detect(PRODUCT_NAME, 'WARM-WATER'), '03061799', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SHRIMP' &
+                           str_detect(PRODUCT_NAME, 'DRIED/SALTED/BRINE'), '03069590', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SHRIMP' &
+                           (str_detect(PRODUCT_NAME, 'ATC') |
+                              str_detect(PRODUCT_NAME, 'CANNED')), '16052900', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'SHRIMP' &
+                           (str_detect(PRODUCT_NAME, 'PREPAR') |
+                              str_detect(PRODUCT_NAME, 'BREADED')), '16052190', `CN-8`))
+
+# smelts
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'SMELT', '03028990', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SMELT' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03038990', `CN-8`))
+
+# snail
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'SNAIL', '03079100', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SNAIL' &
+                           str_detect(PRODUCT_NAME, 'PREPAR'), '16055900', `CN-8`))
+
+# snapper
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'SNAPPER', '03028990', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SNAPPER' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03038990', `CN-8`))
+
+# squid
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'SQUID', '03074220', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SQUID' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03074338', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SQUID' &
+                           (str_detect(PRODUCT_NAME, 'PREPAR') |
+                              str_detect(PRODUCT_NAME, 'CANNED')), '16055400', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SQUID' &
+                           str_detect(PRODUCT_NAME, 'DRIED/SALTED/BRINE'), '03074940', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SQUID' &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03074940', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SQUID' &
+                           str_detect(PRODUCT_NAME, 'FROZEN') &
+                           str_detect(PRODUCT_NAME, 'LOLIGO PEALEI'), '03074333', `CN-8`))
+
+# swordfish
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'SWORDFISH', '03024700', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SWORDFISH' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03035700', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SWORDFISH' &
+                           (str_detect(PRODUCT_NAME, 'FILLET') |
+                              str_detect(PRODUCT_NAME, 'STEAKS')), '03044500', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SWORDFISH' &
+                           str_detect(PRODUCT_NAME, 'FROZEN') &
+                           (str_detect(PRODUCT_NAME, 'FILLET') |
+                              str_detect(PRODUCT_NAME, 'STEAKS')), '03048400', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SWORDFISH' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045400', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'SWORDFISH' &
+                           str_detect(PRODUCT_NAME, 'FROZEN') &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03049100', `CN-8`))
+
+# tilapia
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'TILAPIA', '03027100', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'TILAPIA' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03032300', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'TILAPIA' &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03043100', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'TILAPIA' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045100', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'TILAPIA' &
+                           str_detect(PRODUCT_NAME, 'FILLET') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03046100', `CN-8`))
+
+# toothfish
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'TOOTHFISH', '03028300', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'TOOTHFISH' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03038300', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'TOOTHFISH' &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044600', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'TOOTHFISH' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045500', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'TOOTHFISH' &
+                           str_detect(PRODUCT_NAME, 'FILLET') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03048500', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'TOOTHFISH' &
+                           str_detect(PRODUCT_NAME, 'MEAT') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03049200', `CN-8`))
+
+# trout
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'TROUT', '03021110', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'TROUT' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03031410', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'TROUT' &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044290', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'TROUT' &
+                           str_detect(PRODUCT_NAME, 'FILLET') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03048250', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'TROUT' &
+                           str_detect(PRODUCT_NAME, 'SMOKED'), '03054300', `CN-8`))
+
+# albacore tuna
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_NAME == 'ALBACORE TUNA', '03023190', `CN-8`),
+         `CN-8` = ifelse(SPECIES_NAME == 'ALBACORE TUNA' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03034190', `CN-8`),
+         `CN-8` = ifelse(SPECIES_NAME == 'ALBACORE TUNA' &
+                           str_detect(PRODUCT_NAME, 'ATC'), '16041448', `CN-8`),
+         `CN-8` = ifelse(SPECIES_NAME == 'ALBACORE TUNA' &
+                           str_detect(PRODUCT_NAME, 'LOINS'), '16041931', `CN-8`)) # no loins anywhere
+
+# bigeye tuna
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_NAME == 'BIGEYE TUNA', '03023490', `CN-8`),
+         `CN-8` = ifelse(SPECIES_NAME == 'BIGEYE TUNA' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03034490', `CN-8`))
+
+# bluefin tuna
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(str_detect(PRODUCT_NAME, 'TUNA BLUEFIN'), '03023519', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'TUNA BLUEFIN') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03034518', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'TUNA BLUEFIN') &
+                           str_detect(PRODUCT_NAME, 'SOUTHERN'), '03023690', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'TUNA BLUEFIN') &
+                           str_detect(PRODUCT_NAME, 'PACIFIC'), '03023599', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'TUNA BLUEFIN') &
+                           str_detect(PRODUCT_NAME, 'FROZEN') &
+                           str_detect(PRODUCT_NAME, 'PACIFIC'), '03034599', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'TUNA BLUEFIN') &
+                           str_detect(PRODUCT_NAME, 'FROZEN') &
+                           str_detect(PRODUCT_NAME, 'SOUTHERN'), '03034690', `CN-8`))
+
+# other tuna
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_CATEGORY == 'TUNAS' &
+                           SPECIES_GROUP == '', '03023980', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'TUNAS' &
+                           SPECIES_GROUP == '' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03034985', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'TUNAS' &
+                           SPECIES_GROUP == '' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03049999', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'TUNAS' &
+                           SPECIES_GROUP == '' &
+                           str_detect(PRODUCT_NAME, 'FROZEN') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03048700', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'TUNAS' &
+                           SPECIES_GROUP == '' &
+                           (str_detect(PRODUCT_NAME, 'ATC') |
+                              str_detect(PRODUCT_NAME, 'A.T.C')), '16041441', `CN-8`),
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'TUNAS' &
+                           SPECIES_GROUP == '' &
+                           str_detect(PRODUCT_NAME, 'LOINS'), '16041931', `CN-8`), # no loins anywhere
+         `CN-8` = ifelse(SPECIES_CATEGORY == 'TUNAS' &
+                           SPECIES_GROUP == '' &
+                           str_detect(PRODUCT_NAME, 'PREPAR'), '16041448', `CN-8`))
+
+# skipjack tuna
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_NAME == 'SKIPJACK TUNA', '03023390', `CN-8`),
+         `CN-8` = ifelse(SPECIES_NAME == 'SKIPJACK TUNA' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03034390', `CN-8`))
+
+# yellowfin tuna
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_NAME == 'YELLOWFIN TUNA', '03023290', `CN-8`),
+         `CN-8` = ifelse(SPECIES_NAME == 'YELLOWFIN TUNA' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03034290', `CN-8`),
+         `CN-8` = ifelse(SPECIES_NAME == 'YELLOWFIN TUNA' &
+                           str_detect(PRODUCT_NAME, 'PREPAR'), '16041438', `CN-8`)) # no prepar
+
+# whitefish
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'WHITEFISH', '03028990', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'WHITEFISH' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03038990', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'WHITEFISH' &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044990', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'WHITEFISH' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045990', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'WHITEFISH' &
+                           str_detect(PRODUCT_NAME, 'MEAT') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03049999', `CN-8`))
+
+# wolffish (red fish)
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_GROUP == 'WOLFFISH', '03049950', `CN-8`),
+         `CN-8` = ifelse(SPECIES_GROUP == 'WOLFFISH' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03048929', `CN-8`))
+
+# yellow perch
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(SPECIES_NAME == 'YELLOW PERCH', '03043900', `CN-8`),
+         `CN-8` = ifelse(SPECIES_NAME == 'YELLOW PERCH' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03046900', `CN-8`),
+         `CN-8` = ifelse(SPECIES_NAME == 'YELLOW PERCH' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045990', `CN-8`))
+
+# other molluscs
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(str_detect(PRODUCT_NAME, 'MOLLUSCS NSPF'), '03079100', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'MOLLUSCS NSPF') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03079200', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'MOLLUSCS NSPF') &
+                           str_detect(PRODUCT_NAME, 'DRIED/SALTED/BRINE'), '03079900', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'MOLLUSCS NSPF') &
+                           str_detect(PRODUCT_NAME, 'PREPAR'), '16055900', `CN-8`))
+
+# other crustaceans
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(str_detect(PRODUCT_NAME, 'CRUSTACEANS NSPF'), '03063990', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'CRUSTACEANS NSPF') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03061990', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'CRUSTACEANS NSPF') &
+                           str_detect(PRODUCT_NAME, 'DIRED/SALTED/BRINE'), '03069990', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'CRUSTACEANS NSPF') &
+                           str_detect(PRODUCT_NAME, 'PREPAR'), '16054000', `CN-8`))
+
+# other aquatic inverts
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(str_detect(PRODUCT_NAME, 'AQUATIC INVERTEBRATES'), '03089090', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'AQUATIC INVERTEBRATES') &
+                           str_detect(PRODUCT_NAME, 'PREPAR'), '16056900', `CN-8`))
+
+# other shellfish
+# check what is classified as other shellfish
+
+# cockles
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(str_detect(PRODUCT_NAME, 'COCKLE'), '03077100', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'COCKLE') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03077900', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'COCKLE') &
+                           str_detect(PRODUCT_NAME, 'DRIED/SALTED/BRINE'), '03077900', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'COCKLE') &
+                           str_detect(PRODUCT_NAME, 'PREPAR'), '16055600', `CN-8`))
+
+# fish nspf
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(str_detect(PRODUCT_NAME, 'FISH NSPF') &
+                           ECOLOGICAL_CATEGORY == '', '03028990', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'FISH NSPF') &
+                           ECOLOGICAL_CATEGORY == '' &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045990', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'FISH NSPF') &
+                           ECOLOGICAL_CATEGORY == '' &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03038990', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'FISH NSPF') &
+                           ECOLOGICAL_CATEGORY == '' &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044990', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'FISH NSPF') &
+                           ECOLOGICAL_CATEGORY == '' &
+                           str_detect(PRODUCT_NAME, 'SMOKED'), '03054980', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'FISH NSPF') &
+                           ECOLOGICAL_CATEGORY == '' &
+                           str_detect(PRODUCT_NAME, 'DRIED'), '03055985', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'FISH NSPF') &
+                           ECOLOGICAL_CATEGORY == '' &
+                           str_detect(PRODUCT_NAME, 'SALTED'), '03056980', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'FISH NSPF') &
+                           ECOLOGICAL_CATEGORY == '' &
+                           str_detect(PRODUCT_NAME, 'DRIED/SALTED/BRINE'), '03053990', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'FISH NSPF') &
+                           ECOLOGICAL_CATEGORY == '' &
+                           str_detect(PRODUCT_NAME, 'SURIMI'), '03049910', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'FISH NSPF') &
+                           ECOLOGICAL_CATEGORY == '' &
+                           str_detect(PRODUCT_NAME, 'FILLET') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03048990', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'FISH NSPF') &
+                           ECOLOGICAL_CATEGORY == '' &
+                           (str_detect(PRODUCT_NAME, 'MEAT') |
+                              str_detect(PRODUCT_NAME, 'MINCED')) &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03049999', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'FISH NSPF') &
+                           ECOLOGICAL_CATEGORY == '' &
+                           str_detect(PRODUCT_NAME, 'PREPAR'), '16042090', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'FISH NSPF') &
+                           ECOLOGICAL_CATEGORY == '' &
+                           (str_detect(PRODUCT_NAME, 'ATC') |
+                              str_detect(PRODUCT_NAME, 'CANNED')), '16041997', `CN-8`))
+
+# marine fish nspf
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(str_detect(PRODUCT_NAME, 'MARINE FISH NSPF'), '03028990', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'MARINE FISH NSPF') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03038990', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'MARINE FISH NSPF') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044990', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'MARINE FISH NSPF') &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045990', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'MARINE FISH NSPF') &
+                           str_detect(PRODUCT_NAME, 'FILLET') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03048990', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'MARINE FISH NSPF') &
+                           str_detect(PRODUCT_NAME, 'MEAT') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03049999', `CN-8`))
+
+# freshwater fish nspf
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(str_detect(PRODUCT_NAME, 'FRESHWATER FISH NSPF'), '03028910', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'FRESHWATER FISH NSPF') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03038910', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'FRESHWATER FISH NSPF') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044910', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'FRESHWATER FISH NSPF') &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045910', `CN-8`), 
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'FRESHWATER FISH NSPF') &
+                           str_detect(PRODUCT_NAME, 'FILLET') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03048910', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'FRESHWATER FISH NSPF') &
+                           str_detect(PRODUCT_NAME, 'MEAT') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03049921', `CN-8`))
+
+# pike, pickerel, pike perch, yellow pike
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(HTS_NUMBER %in% c('302895025'), '03028910', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'PIKE PERCH'), '03028990', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'PIKE PERCH') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03038990', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'PIKE PERCH') &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044990', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'PIKE PERCH') &
+                           str_detect(PRODUCT_NAME, 'FILLET') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03048990', `CN-8`),
+         `CN-8` = ifelse(str_detect(PRODUCT_NAME, 'PIKE PERCH') &
+                           str_detect(PRODUCT_NAME, 'MEAT'), '03045990', `CN-8`))
+
+# remaining HTS codes
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(HTS_NUMBER %in% c('1605900500'), '16055900', `CN-8`))
+
+# cetacea, use other fish codes
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(HTS_NUMBER %in% c('208400000', '208400100'), '03045990', `CN-8`), 
+         `CN-8` = ifelse(HTS_NUMBER %in% c('210920100'), '03054980', `CN-8`))
+
+
+# Find HTS not yet assigned to CN8 ---------------------------------------------
+# isolate HTS unassigned
+free_hts <- us_hts_cn8 %>%
+  filter(`CN-8` == '') %>%
+  select(HTS_NUMBER) %>%
+  distinct()
+
+# pull hts to species groups from hts_to_species_group.R
+hts_species_groups <- read.csv('C:/Users/cameron.vanhorn/Documents/GitHub/seafood-traceability-design/species_group_hts.csv') %>%
+  # convert numeric to character
+  mutate(HTS.Number = as.character(HTS.Number)) %>%
+  rename(HTS_NUMBER = HTS.Number,
+         SPECIES_GROUP = species_group) %>%
+  select(!c(X, Product.Name)) %>%
+  distinct()
+
+hts_species_leftovers <- left_join(free_hts, hts_species_groups) %>%
+  left_join(trade_data %>% select(HTS_NUMBER, PRODUCT_NAME) %>% distinct()) %>%
+  filter(!is.na(SPECIES_GROUP))
+
+
+# Assign CN8 to leftover HTS ---------------------------------------------------
+# bass
+bass_hts <- hts_species_leftovers %>%
+  filter(str_detect(SPECIES_GROUP, 'bass')) %>%
+  pull(HTS_NUMBER)
+
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(HTS_NUMBER %in% bass_hts, '03028410', `CN-8`))
+
+# bonito
+bonito_hts <- hts_species_leftovers %>%
+  filter(str_detect(SPECIES_GROUP, 'bonito')) %>%
+  pull(HTS_NUMBER)
+
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(HTS_NUMBER %in% bonito_hts, '16041490', `CN-8`))
+
+# cusk
+cusk_hts <- hts_species_leftovers %>%
+  filter(str_detect(SPECIES_GROUP, 'cusk')) %>%
+  pull(HTS_NUMBER)
+
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(HTS_NUMBER %in% cusk_hts &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03036980', `CN-8`),
+         `CN-8` = ifelse(HTS_NUMBER %in% cusk_hts &
+                           str_detect(PRODUCT_NAME, 'SALTED'), '03056910', `CN-8`),
+         `CN-8` = ifelse(HTS_NUMBER %in% cusk_hts &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044990', `CN-8`))
+
+# hake
+hake_hts <- hts_species_leftovers %>%
+  filter(str_detect(SPECIES_GROUP, 'hake')) %>%
+  pull(HTS_NUMBER)
+
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(HTS_NUMBER %in% hake_hts, '03025419', `CN-8`),
+         `CN-8` = ifelse(HTS_NUMBER %in% hake_hts &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03036619', `CN-8`),
+         `CN-8` = ifelse(HTS_NUMBER %in% hake_hts &
+                           str_detect(PRODUCT_NAME, 'FILLET'), '03044490', `CN-8`),
+         `CN-8` = ifelse(HTS_NUMBER %in% hake_hts &
+                           str_detect(PRODUCT_NAME, 'FILLET') &
+                           str_detect(PRODUCT_NAME, 'FROZEN'), '03047419', `CN-8`))
+
+# herring
+herring_hts <- hts_species_leftovers %>%
+  filter(str_detect(SPECIES_GROUP, 'herring')) %>%
+  pull(HTS_NUMBER)
+
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(HTS_NUMBER %in% herring_hts, '03024100', `CN-8`))
+
+# shark
+shark_hts <- hts_species_leftovers %>%
+  filter(str_detect(SPECIES_GROUP, 'shark')) %>%
+  pull(HTS_NUMBER)
+
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(HTS_NUMBER %in% shark_hts, '16041800', `CN-8`))
+
+# shrimp
+shrimp_hts <- hts_species_leftovers %>%
+  filter(str_detect(SPECIES_GROUP, 'shrimp')) %>%
+  pull(HTS_NUMBER)
+
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(HTS_NUMBER %in% shrimp_hts, '03063690', `CN-8`),
+         `CN-8` = ifelse(HTS_NUMBER %in% shrimp_hts &
+                           str_detect(PRODUCT_NAME, 'ATC'), '16052900', `CN-8`))
+
+# whiting
+whiting_hts <- hts_species_leftovers %>%
+  filter(str_detect(SPECIES_GROUP, 'whiting')) %>%
+  pull(HTS_NUMBER)
+
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(HTS_NUMBER %in% whiting_hts, '03047930', `CN-8`))
+
+# other shellfish
+shellfish_hts <- hts_species_leftovers %>%
+  filter(str_detect(SPECIES_GROUP, 'shellfish')) %>%
+  pull(HTS_NUMBER)
+
+us_hts_cn8 <- us_hts_cn8 %>%
+  mutate(`CN-8` = ifelse(HTS_NUMBER %in% shellfish_hts, '16042005', `CN-8`))
+
+
+# Attach Conversion Factors, export data ---------------------------------------
+conversion_factors <- left_join(us_hts_cn8, eumofa %>% select(`CN-8`, CF))
+
+write.csv(conversion_factors, 'conversion_factors.csv')

--- a/conversion_factors/hts_to_species_group.R
+++ b/conversion_factors/hts_to_species_group.R
@@ -1,0 +1,154 @@
+# get species groups assigned to HTS codes from Steinkruger et al. (2024) github
+# Original Authors: Kaitlyn Malakoff and Kailin Kroetz
+# Author: Cameron Van Horn
+#         cameron.vanhorn@noaa.gov
+
+# The purpose of this code is to attach species groups to HTS codes originally
+  # performed by Malakoff and Kroetz in Linkage_HTS_nmfs_group.R provided at 
+  # github.com/kaitlyn-c-lee/seafood-traceability-design/tree/main
+# The files drawn here are found in Source Data/NOAA_imports/byspeciesgroup at
+  # the above mentioned github. There is no original code provided by Van Horn
+  # in this script.
+
+library(tidyverse)
+library(readxl)
+library(plyr)
+
+filenames <- list.files("Source Data/NOAA_imports/byspeciesgroup", pattern = '*.csv', full.names = T)
+filenames <- filenames[2:134]
+
+data_list <- lapply(seq_along(filenames), 
+                    function(x) transform(read_csv(filenames[x], skip = 1),
+                                          file = filenames[x]))
+
+noaa_imports <- ldply(data_list, data.frame) %>%
+  filter(Year >= 2004)
+detach(package:plyr)
+  
+rm(data_list)
+
+noaa_data <- noaa_imports %>%
+  rename(species_group = file) %>%
+  mutate(species_group = str_remove_all(species_group, 'Source Data/NOAA_imports/byspeciesgroup/'),
+         species_group = str_remove_all(species_group, '.csv'),
+         species_group = str_remove_all(species_group, ' pre 1990'),
+         species_group = str_remove_all(species_group, ' 1990 on')) %>%
+  group_by(species_group, HTS.Number, Product.Name) %>%
+  summarise() %>%
+  arrange(HTS.Number)
+
+dup_groups <- c('other', 'fillet', 'tuna_atc', 'canned_salmon', 'roe', 'surimi', 
+                'other edible 2', 'rays and skates')
+noaa_data <- noaa_data %>% filter(!species_group %in% dup_groups)
+
+byproducts <- c('animal feed', 'fish balls', 'fish meal', 'fish glue', 'fish oil',
+                'fish pastes and sauces', 'fish solubles', 'seaweed nonedible', 
+                'other nonedible', 'agar agar', 'other edible', 'ambergris',
+                'sponges', 'sticks', 'frogs', 'reptile', 'fish pastes and sauces 2')
+byproducts_hts <- noaa_data %>%
+  filter(species_group %in% byproducts)
+byproducts_hts_output <- rbind(byproducts_hts, noaa_data %>%
+                                 filter(HTS.Number == '0004550600'))
+
+noaa_data <- noaa_data %>% filter(!species_group %in% byproducts_hts$species_group)
+
+
+all_groups <- noaa_data %>% filter(str_detect(species_group, "all_"))
+
+# groundfish
+all_groundfish <- noaa_data %>% filter(str_detect(species_group, "_groundfish"))
+specific_groundfish <- all_groundfish %>% filter(!str_detect(species_group, "all_"))
+other_groundfish <- all_groundfish %>% filter(!HTS.Number %in% specific_groundfish$HTS.Number)
+other_groundfish$species_group <- "other_groundfish"
+rm(all_groundfish, specific_groundfish)
+
+# flatfish
+all_flatfish <- noaa_data %>% filter(str_detect(species_group, "_flatfish"))
+specific_flatfish <- all_flatfish %>% filter(!str_detect(species_group, "all_"))
+other_flatfish <- all_flatfish %>% filter(!HTS.Number %in% specific_flatfish$HTS.Number)
+other_flatfish$species_group <- "other_flatfish"
+rm(all_flatfish, specific_flatfish)
+
+other_species_groups <- rbind(other_groundfish, other_flatfish)
+rm(other_groundfish, other_flatfish)
+
+# Salmon
+all_salmon <- noaa_data %>% filter(str_detect(species_group, "_salmon"))
+specific_salmon <- all_salmon %>% filter(!str_detect(species_group, "all_"))
+other_salmon <- all_salmon %>% filter(!HTS.Number %in% specific_salmon$HTS.Number)
+other_salmon$species_group <- "other_salmon"
+rm(all_salmon, specific_salmon)
+
+other_species_groups <- rbind(other_species_groups, other_salmon)
+rm(other_salmon)
+
+# tuna
+all_tuna <- noaa_data %>% filter(str_detect(species_group, "_tuna"))
+specific_tuna <- all_tuna %>% filter(!str_detect(species_group, "all_"))
+other_tuna <- all_tuna %>% filter(!HTS.Number %in% specific_tuna$HTS.Number)
+other_tuna$species_group <- "other_tuna"
+rm(all_tuna, specific_tuna)
+
+other_species_groups <- rbind(other_species_groups, other_tuna)
+rm(other_tuna)
+
+# crab 
+all_crab <- noaa_data %>% filter(str_detect(species_group, "_crab"))
+specific_crab <- all_crab %>% filter(!str_detect(species_group, "all_"))
+other_crab <- all_crab %>% filter(!HTS.Number %in% specific_crab$HTS.Number)
+other_crab$species_group <- "other_crab"
+rm(all_crab, specific_crab)
+
+other_species_groups <- rbind(other_species_groups, other_crab)
+rm(other_crab)
+
+# remove all_ and _other from main data
+noaa_data <- noaa_data %>% filter(!str_detect(species_group, "all_"))
+noaa_data <- noaa_data %>% filter(!str_detect(species_group, "_other"))
+
+# Remove anything else with HTS codes in the _other category so as not to overwrite later
+noaa_data <- noaa_data %>% filter(!HTS.Number %in% other_species_groups$HTS.Number)
+
+# add back to main dataset
+noaa_data <- rbind(noaa_data,other_species_groups)
+
+rm(all_groups, other_species_groups)
+
+noaa_data_copy <- noaa_data
+
+nspf_groups <- c('freshwater fish nspf', 'marine fish nspf', 'other freshwater',
+                 'fish nspf')
+noaa_data <- noaa_data %>% filter(!species_group %in% nspf_groups)
+
+
+# remove duplicate other molluscs
+remove <- noaa_data %>% filter(species_group=="other shellfish" & str_detect(Product.Name, "MOLLUSCS"))
+noaa_data <- setdiff(noaa_data, remove)
+
+# remove duplicated mackerel
+mackerel <- noaa_data %>% filter(species_group=="mackerel")
+mackerel_subspecies <- noaa_data %>% filter(species_group!="mackerel" & str_detect(species_group, "mackerel"))
+
+mackerel <- mackerel %>% filter(HTS.Number %in% mackerel_subspecies$HTS.Number)
+
+noaa_data <- noaa_data %>% filter(!HTS.Number %in% mackerel$HTS.Number)
+noaa_data <- rbind(noaa_data,mackerel_subspecies)
+
+# sea bass
+noaa_data <- noaa_data %>% filter(!(species_group=="bass" & str_detect(Product.Name, "SEA BASS")))
+
+# danube salmon
+noaa_data <- noaa_data %>% filter(!(species_group=="danube_salmon" & str_detect(Product.Name, "DANUBE")))
+
+# perch / ocean perch 
+noaa_data <- noaa_data %>% filter(!(species_group=="perch nspf" & str_detect(Product.Name, "OCEAN PERCH")))
+
+# Manually define "Blue crab"
+noaa_data$species_group <- if_else(str_detect(noaa_data$Product.Name, "CALLINECTES"), "blue_crab", noaa_data$species_group)
+
+# All remaining duplicates are multi-species, remove
+remaining_dups <- noaa_data[duplicated(noaa_data$HTS.Number),]
+
+noaa_data <- noaa_data %>% filter(!HTS.Number %in% remaining_dups$HTS.Number)
+
+write.csv(noaa_data, 'species_group_hts.csv')

--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -1071,10 +1071,10 @@ calculate_supply_metrics <- function(species, region, units = NULL, nominal = F)
     # calculate unexported domestic production relative to apparent supply by
     # dividing the absolute value of the difference of domestic production and
     # export volume by apparent supply
-    mutate(APPARENT_SUPPLY = (PP_VOLUME_T - EXP_VOLUME_T) + IMP_VOLUME_T,
+    mutate(APPARENT_SUPPLY = (PP_VOLUME_T - EXP_ROUND_VOLUME_T) + IMP_ROUND_VOLUME_T,
            APPARENT_SUPPLY_REL_US_PROD = APPARENT_SUPPLY / PP_VOLUME_T,
            UNEXPORTED_US_PROD_REL_APPARENT_SUPPLY = 
-             abs(PP_VOLUME_T - EXP_VOLUME_T) / APPARENT_SUPPLY,
+             abs(PP_VOLUME_T - EXP_ROUND_VOLUME_T) / APPARENT_SUPPLY,
            SPECIES = species) 
   
   return(data)

--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -26,7 +26,7 @@ addResourcePath("tmpuser", getwd())
 
 # Pull Data (most recent version)
 # load('seafood_trade_data_munge_05_12_25.RData')
-load('seafood_trade_data_munge_09_26_25.RData')
+load('seafood_trade_data_munge_10_07_25.RData')
 
 # filter out confidential data (no data contained therein)
 com_landings <- com_landings %>%

--- a/dashboard_draft/app.R
+++ b/dashboard_draft/app.R
@@ -262,8 +262,9 @@ summarize_trade_yr_spp <- function(trade_table, species, region, output.format,
   summarized_data <- trade_table %>%
     filter_species(species) %>%
     filter_region(region) %>%
-    select(YEAR, !!level, EXP_VALUE_2024USD, EXP_VOLUME_KG, 
-           IMP_VALUE_2024USD, IMP_VOLUME_KG, EXP_VALUE_USD, IMP_VALUE_USD) %>%
+    select(YEAR, !!level, EXP_VALUE_2024USD, EXP_VOLUME_KG, EXP_CONVERTED_VOLUME,
+           IMP_VALUE_2024USD, IMP_VOLUME_KG, IMP_CONVERTED_VOLUME, EXP_VALUE_USD, 
+           IMP_VALUE_USD) %>%
     mutate(EXP_VALUE_2024USD = ifelse(is.na(EXP_VALUE_2024USD), 0,
                                       EXP_VALUE_2024USD),
            IMP_VALUE_2024USD = ifelse(is.na(IMP_VALUE_2024USD), 0,
@@ -272,6 +273,10 @@ summarize_trade_yr_spp <- function(trade_table, species, region, output.format,
                                   EXP_VOLUME_KG),
            IMP_VOLUME_KG = ifelse(is.na(IMP_VOLUME_KG), 0,
                                   IMP_VOLUME_KG),
+           EXP_CONVERTED_VOLUME = ifelse(is.na(EXP_CONVERTED_VOLUME), 0,
+                                         EXP_CONVERTED_VOLUME),
+           IMP_CONVERTED_VOLUME = ifelse(is.na(IMP_CONVERTED_VOLUME), 0,
+                                         IMP_CONVERTED_VOLUME),
            EXP_VALUE_USD = ifelse(is.na(EXP_VALUE_USD), 0,
                                   EXP_VALUE_USD),
            IMP_VALUE_USD = ifelse(is.na(IMP_VALUE_USD), 0,
@@ -284,6 +289,8 @@ summarize_trade_yr_spp <- function(trade_table, species, region, output.format,
     new_data <- summarized_data %>%
       mutate(EXP_VOLUME_LB = EXP_VOLUME_KG * 2.20462,
              IMP_VOLUME_LB = IMP_VOLUME_KG * 2.20462,
+             EXP_ROUND_VOLUME_LB = EXP_CONVERTED_VOLUME * 2.20462,
+             IMP_ROUND_VOLUME_LB = IMP_CONVERTED_VOLUME * 2.20462,
              EXP_PRICE_USD_PER_KG = EXP_VALUE_2024USD / EXP_VOLUME_KG,
              IMP_PRICE_USD_PER_KG = IMP_VALUE_2024USD / IMP_VOLUME_KG,
              EXP_PRICE_USD_PER_LB = EXP_VALUE_2024USD / EXP_VOLUME_LB,
@@ -302,23 +309,35 @@ summarize_trade_yr_spp <- function(trade_table, species, region, output.format,
              IMP_VALUE_BILLIONS = IMP_VALUE_USD / 1000000000,
              EXP_VOLUME_MT = EXP_VOLUME_KG / 1000,
              IMP_VOLUME_MT = IMP_VOLUME_KG / 1000,
+             EXP_ROUND_VOLUME_MT = EXP_CONVERTED_VOLUME / 1000,
+             IMP_ROUND_VOLUME_MT = IMP_CONVERTED_VOLUME / 1000,
              EXP_VOLUME_ST = EXP_VOLUME_LB / 2000,
-             IMP_VOLUME_ST = IMP_VOLUME_LB / 2000)
+             IMP_VOLUME_ST = IMP_VOLUME_LB / 2000,
+             EXP_ROUND_VOLUME_ST = EXP_ROUND_VOLUME_LB / 2000,
+             IMP_ROUND_VOLUME_ST = IMP_ROUND_VOLUME_LB / 2000)
     return(new_data)
   }
   
   if (units == 'METRIC') {
     new_data <- summarized_data %>%
       rename(EXP_VOLUME = EXP_VOLUME_KG,
-             IMP_VOLUME = IMP_VOLUME_KG) %>%
+             IMP_VOLUME = IMP_VOLUME_KG,
+             EXP_ROUND_VOLUME = EXP_CONVERTED_VOLUME,
+             IMP_ROUND_VOLUME = IMP_CONVERTED_VOLUME) %>%
       mutate(EXP_VOLUME_T = EXP_VOLUME / 1000,
-             IMP_VOLUME_T = IMP_VOLUME / 1000)
+             IMP_VOLUME_T = IMP_VOLUME / 1000,
+             EXP_ROUND_VOLUME_T = EXP_ROUND_VOLUME / 1000,
+             IMP_ROUND_VOLUME_T = IMP_ROUND_VOLUME / 1000)
   } else if (units == 'IMPERIAL') {
     new_data <- summarized_data %>%
       mutate(EXP_VOLUME = EXP_VOLUME_KG * 2.20462, # convert kg to lbs
              IMP_VOLUME = IMP_VOLUME_KG * 2.20462,
+             EXP_ROUND_VOLUME = EXP_CONVERTED_VOLUME * 2.20462,
+             IMP_ROUND_VOLUME = IMP_CONVERTED_VOLUME * 2.20462,
              EXP_VOLUME_T = EXP_VOLUME / 2000, # calculate short tons
-             IMP_VOLUME_T = IMP_VOLUME / 2000) %>%
+             IMP_VOLUME_T = IMP_VOLUME / 2000,
+             EXP_ROUND_VOLUME_T = EXP_ROUND_VOLUME / 2000,
+             IMP_ROUND_VOLUME_T = IMP_ROUND_VOLUME / 2000) %>%
       select(!c(EXP_VOLUME_KG, IMP_VOLUME_KG))
   }
   
@@ -360,7 +379,8 @@ summarize_trade_yr_spp <- function(trade_table, species, region, output.format,
     trade_data <- new_data %>%
       select(YEAR, EXP_VALUE, IMP_VALUE, EXP_VALUE_MILLIONS, IMP_VALUE_MILLIONS, 
              EXP_PRICE, IMP_PRICE, EXP_VOLUME_T, IMP_VOLUME_T, EXP_VOLUME,
-             IMP_VOLUME) %>%
+             IMP_VOLUME, EXP_ROUND_VOLUME, IMP_ROUND_VOLUME, EXP_ROUND_VOLUME_T,
+             IMP_ROUND_VOLUME_T) %>%
       mutate(RATIO = EXP_VOLUME_T / IMP_VOLUME_T)
     
     return(trade_data)


### PR DESCRIPTION
Trade data now includes converted round weight values calculated via EUMOFA conversion factors linked via HTS numbers. The EUMOFA link effort followed that of Steinkruger et al. (2024) provided at (https://github.com/kaitlyn-c-lee/seafood-traceability-design/tree/main). The code was authored by Kaitlyn Malakoff and Kailin Kroetz. Here, we adapted their effort by linking their species groups to our species classifications such that the CN-8 codes linked to their species groups could link to our species and thus our HTS codes. 

Conversion factors are only available for trade data, and the only calculated and visual data affected are found in supply metrics (Apparent Supply, Apparent Supply relative to Domestic Production, and Unexported domestic production relative to apparent supply). 